### PR TITLE
Fix to hold keys

### DIFF
--- a/DirectX11/Override.cpp
+++ b/DirectX11/Override.cpp
@@ -455,8 +455,14 @@ void Override::Activate(HackerDevice *device, bool override_has_deactivate_condi
 		return;
 	}
 
-	LogInfo("User key activation -->\n");
+	//don't re-activate if already active, this causes a jam in hold overrides
+	if (active) {
+		LogInfo("Skipping override activation: already active\n");
+		return;
+	}
 
+	LogInfo("User key activation -->\n");
+	
 	if (override_has_deactivate_condition) {
 		active = true;
 		OverrideSave.Save(device, this);

--- a/DirectX11/Override.cpp
+++ b/DirectX11/Override.cpp
@@ -455,12 +455,6 @@ void Override::Activate(HackerDevice *device, bool override_has_deactivate_condi
 		return;
 	}
 
-	//don't re-activate if already active, this causes a jam in hold overrides
-	if (active) {
-		LogInfo("Skipping override activation: already active\n");
-		return;
-	}
-
 	LogInfo("User key activation -->\n");
 	
 	if (override_has_deactivate_condition) {
@@ -521,7 +515,7 @@ void KeyOverride::DownEvent(HackerDevice *device)
 	if (type == KeyOverrideType::TOGGLE)
 		return Toggle(device);
 
-	if (type == KeyOverrideType::HOLD)
+	if (type == KeyOverrideType::HOLD && !active)
 		return Activate(device, true);
 
 	return Activate(device, false);


### PR DESCRIPTION
Simple fix for the resetting of hold keys

When you have multiple `key = ` statements for a single override, pressing more than one of the keys before releasing would overwrite the "reset" condition, and make it impossible to go back to the original value after releasing the keys. This should fix it.