### PR TITLE
Fix for Persist Variables getting Cleared by Auto-Save

### DIFF
--- a/Dependencies/d3dx.ini
+++ b/Dependencies/d3dx.ini
@@ -168,6 +168,9 @@ reload_config = no_modifiers VK_F10
 ; Deletes the d3dx_user.ini file and reloads settings to get a "clean slate"
 wipe_user_config = ctrl alt no_shift VK_F10
 
+; Auto Clears Persistent Variables on the 2nd Config Reload after they became Unrecognisable (Changed Namespace/Disabled Mod/Changed Variable itself)
+auto_clear_persist_vars = 1
+
 ; Hold this key to temporarily disable the fix - useful to quickly check what
 ; an effect looked like in the original game.
 show_original = no_modifiers VK_F9

--- a/Dependencies/d3dx.ini
+++ b/Dependencies/d3dx.ini
@@ -168,9 +168,6 @@ reload_config = no_modifiers VK_F10
 ; Deletes the d3dx_user.ini file and reloads settings to get a "clean slate"
 wipe_user_config = ctrl alt no_shift VK_F10
 
-; Auto Clears Persistent Variables on the 2nd Config Reload after they became Unrecognisable (Changed Namespace/Disabled Mod/Changed Variable itself)
-auto_clear_persist_vars = 1
-
 ; Hold this key to temporarily disable the fix - useful to quickly check what
 ; an effect looked like in the original game.
 show_original = no_modifiers VK_F9
@@ -521,6 +518,8 @@ config_initialization_delay = 0
 ; Set to -1 to disable if not required.
 settings_auto_save_interval = 60
 
+; Controls whether saved values of persistent variables should be cleared when source mods are no longer detected (disabled or removed).
+auto_clear_persist_vars = 1
 
 ;------------------------------------------------------------------------------------------------------
 ; Settings to force display device to a specific mode.

--- a/DirectX11/CommandList.cpp
+++ b/DirectX11/CommandList.cpp
@@ -25,6 +25,7 @@ CustomShaders customShaders;
 ExplicitCommandListSections explicitCommandListSections;
 CommandListVariables command_list_globals;
 std::vector<CommandListVariable*> persistent_variables;
+std::unordered_map<std::wstring, float> saved_variables;
 std::vector<CommandList*> registered_command_lists;
 std::unordered_set<CommandList*> command_lists_profiling;
 std::unordered_set<CommandListCommand*> command_lists_cmd_profiling;

--- a/DirectX11/CommandList.cpp
+++ b/DirectX11/CommandList.cpp
@@ -5515,6 +5515,9 @@ bool ParseCommandListVariableAssignment(const wchar_t *section,
 	if (name.back() == L']')
 		return false;
 
+	if (G->frame_no == 0 && *ini_namespace == G->user_config)
+		saved_variables[name] = GetIniFloat(section, name.c_str(), 0.0f, NULL);
+
 	CommandListVariable* var = nullptr;
 
 	if (!args.GetVariable(var, false, CommandArgumentReader::PeekMode::Argument))

--- a/DirectX11/CommandList.h
+++ b/DirectX11/CommandList.h
@@ -148,6 +148,7 @@ public:
 typedef std::unordered_map<std::wstring, class CommandListVariable> CommandListVariables;
 extern CommandListVariables command_list_globals;
 extern std::vector<CommandListVariable*> persistent_variables;
+extern std::unordered_map<std::wstring, float> saved_variables;
 
 // The scope object is used to declare local variables in a command list. The
 // multiple levels are to isolate variables declared inside if blocks from

--- a/DirectX11/Hunting.cpp
+++ b/DirectX11/Hunting.cpp
@@ -1971,7 +1971,6 @@ void ParseHuntingSection()
 	// find the effect again later.
 	G->config_reloadable = RegisterIniKeyBinding(L"Hunting", L"reload_config", FlagConfigReload, NULL, noRepeat, NULL);
 	G->config_reloadable = RegisterIniKeyBinding(L"Hunting", L"wipe_user_config", FlagConfigReload, NULL, noRepeat, (void*)true);
-	G->auto_clear_persist_vars = GetIniBool(L"Hunting", L"auto_clear_persist_vars", true, NULL);
 
 	// We're interested in performance measurements even in release mode
 	// (possibly even especially in release mode), particularly if we want

--- a/DirectX11/Hunting.cpp
+++ b/DirectX11/Hunting.cpp
@@ -1971,6 +1971,7 @@ void ParseHuntingSection()
 	// find the effect again later.
 	G->config_reloadable = RegisterIniKeyBinding(L"Hunting", L"reload_config", FlagConfigReload, NULL, noRepeat, NULL);
 	G->config_reloadable = RegisterIniKeyBinding(L"Hunting", L"wipe_user_config", FlagConfigReload, NULL, noRepeat, (void*)true);
+	G->auto_clear_persist_vars = GetIniBool(L"Hunting", L"auto_clear_persist_vars", true, NULL);
 
 	// We're interested in performance measurements even in release mode
 	// (possibly even especially in release mode), particularly if we want

--- a/DirectX11/IniHandler.cpp
+++ b/DirectX11/IniHandler.cpp
@@ -2293,7 +2293,7 @@ static void ParseCommandList(const wchar_t *id,
 					LogOverlay(LOG_WARNING,
 						"NOTICE: Unknown User Settings will be Removed from d3dx_user.ini\n"
 						" This is Normal if you recently Removed/Changed any Mods\n"
-						" Change auto_clear_persist_vars inside d3dx.ini to change this behaviour\n"
+						" Set auto_clear_persist_vars to 0 inside d3dx.ini to Disable Automatic Clean-up\n"
 						" Press %S to Update the Config now, or %S to Reset all Settings to Default\n"
 						" The first Unrecognised Entry was: \"%S\"\n",
 						user_friendly_ini_key_binding(L"Hunting", L"reload_config").c_str(),
@@ -2302,7 +2302,7 @@ static void ParseCommandList(const wchar_t *id,
 				else
 					LogOverlay(LOG_WARNING,
 						"NOTICE: Unknown User Settings won't be Removed from d3dx_user.ini\n"
-						" Change auto_clear_persist_vars inside d3dx.ini to change this behaviour\n"
+						" Set auto_clear_persist_vars to 1 inside d3dx.ini to Enable Automatic Clean-up\n"
 						" Press %S to Update the Config now, or %S to Reset all Settings to Default\n"
 						" The first Unrecognised Entry was: \"%S\"\n",
 						user_friendly_ini_key_binding(L"Hunting", L"reload_config").c_str(),
@@ -4888,26 +4888,15 @@ void SavePersistentSettings()
 	      "[Constants]\n", f);
 
 
-	if (!G->gReloadConfigPending || !G->auto_clear_persist_vars) {
-
-		for (auto global : persistent_variables) {
-			fprintf_s(f, "%ls = %.9g\n", global->name.c_str(), global->fval);
-			saved_variables.erase(global->name);
-		}
-
-		for (auto& entry : saved_variables)
-			fprintf_s(f, "%ls = %.9g\n", entry.first.c_str(), entry.second);
+	for (auto global : persistent_variables) {
+		fprintf_s(f, "%ls = %.9g\n", global->name.c_str(), global->fval);
+		saved_variables.erase(global->name);
 	}
-	
-	else {
-		for (auto global : persistent_variables) {
-			fprintf_s(f, "%ls = %.9g\n", global->name.c_str(), global->fval);
-			saved_variables.erase(global->name);
-		}
 
-		for (auto& entry : saved_variables)
-			fprintf_s(f, "%ls = %.9g\n", entry.first.c_str(), entry.second);
+	for (auto& entry : saved_variables)
+		fprintf_s(f, "%ls = %.9g\n", entry.first.c_str(), entry.second);
 
+	if (G->gReloadConfigPending && G->auto_clear_persist_vars) {
 		if (G->clear_saved_persist_vars) {
 			saved_variables.clear();
 			G->clear_saved_persist_vars = false;

--- a/DirectX11/IniHandler.cpp
+++ b/DirectX11/IniHandler.cpp
@@ -2289,14 +2289,26 @@ static void ParseCommandList(const wchar_t *id,
 			// the user config to be updated at the next save, but won't do this
 			// immediately just in case. Inform the user of what is happening.
 			if (!G->user_config_dirty) {
-				LogOverlay(LOG_WARNING,
-					"NOTICE: Unknown user settings will be removed from d3dx_user.ini\n"
-					" This is normal if you recently removed/changed any mods\n"
-					" Press %S to update the config now, or %S to reset all settings to default\n"
-					" The first unrecognised entry was: \"%S\"\n",
-					user_friendly_ini_key_binding(L"Hunting", L"reload_config").c_str(),
-					user_friendly_ini_key_binding(L"Hunting", L"wipe_user_config").c_str(),
-					raw_line->c_str());
+				if (G->auto_clear_persist_vars)
+					LogOverlay(LOG_WARNING,
+						"NOTICE: Unknown User Settings will be Removed from d3dx_user.ini\n"
+						" This is Normal if you recently Removed/Changed any Mods\n"
+						" Change auto_clear_persist_vars inside d3dx.ini to change this behaviour\n"
+						" Press %S to Update the Config now, or %S to Reset all Settings to Default\n"
+						" The first Unrecognised Entry was: \"%S\"\n",
+						user_friendly_ini_key_binding(L"Hunting", L"reload_config").c_str(),
+						user_friendly_ini_key_binding(L"Hunting", L"wipe_user_config").c_str(),
+						raw_line->c_str());
+				else
+					LogOverlay(LOG_WARNING,
+						"NOTICE: Unknown User Settings won't be Removed from d3dx_user.ini\n"
+						" Change auto_clear_persist_vars inside d3dx.ini to change this behaviour\n"
+						" Press %S to Update the Config now, or %S to Reset all Settings to Default\n"
+						" The first Unrecognised Entry was: \"%S\"\n",
+						user_friendly_ini_key_binding(L"Hunting", L"reload_config").c_str(),
+						user_friendly_ini_key_binding(L"Hunting", L"wipe_user_config").c_str(),
+						raw_line->c_str());
+
 				// Once the [Constants] command list has finished running the
 				// low bit will be cleared to ensure that loading the user config
 				// itself cannot mark the user config as dirty. Set the second
@@ -4843,18 +4855,7 @@ void SavePersistentSettings()
 
 	G->gSettingsSaveTime = G->gTime;
 
-	if (!G->user_config_dirty)
-		return;
-
-	setlocale(LC_CTYPE, "en_US.UTF-8");
-
-	// TODO: Ability to update existing file rather than overwriting:
-	//wfopen_ensuring_access(&f, G->user_config.c_str(), L"r+");
-	//if (!f)
-
-	std::unordered_map<std::wstring, float> saved_variables;
-
-	if (!G->gReloadConfigPending) {
+	if (!G->user_config_dirty || !G->gConfigInitialized) {
 
 		// Read Existing Variables from File.
 		if (_wfopen_s(&f, G->user_config.c_str(), L"r") == 0 && f) {
@@ -4872,11 +4873,8 @@ void SavePersistentSettings()
 
 				wchar_t* name_end = equals - 1;
 
-				while (name_end >= line &&
-					(*name_end == L' ' || *name_end == L'\t'))
-				{
+				while (name_end >= line && (*name_end == L' ' || *name_end == L'\t'))
 					name_end--;
-				}
 
 				*(name_end + 1) = L'\0';
 
@@ -4889,7 +4887,16 @@ void SavePersistentSettings()
 
 			fclose(f);
 		}
+
+		return;
 	}
+	
+
+	setlocale(LC_CTYPE, "en_US.UTF-8");
+
+	// TODO: Ability to update existing file rather than overwriting:
+	//wfopen_ensuring_access(&f, G->user_config.c_str(), L"r+");
+	//if (!f)
 
 	wfopen_ensuring_access(&f, G->user_config.c_str(), L"w");
 	if (!f) {
@@ -4909,7 +4916,7 @@ void SavePersistentSettings()
 	      "[Constants]\n", f);
 
 
-	if (!G->gReloadConfigPending) {
+	if (!G->gReloadConfigPending || !G->auto_clear_persist_vars) {
 
 		for (auto global : persistent_variables) {
 			fprintf_s(f, "%ls = %.9g\n", global->name.c_str(), global->fval);
@@ -4921,12 +4928,18 @@ void SavePersistentSettings()
 	}
 	
 	else {
-		for (auto global : persistent_variables)
+		for (auto global : persistent_variables) {
 			fprintf_s(f, "%ls = %.9g\n", global->name.c_str(), global->fval);
+			saved_variables.erase(global->name);
+		}
 
-		G->user_config_dirty = 0;
+		for (auto& entry : saved_variables)
+			fprintf_s(f, "%ls = %.9g\n", entry.first.c_str(), entry.second);
+
+		saved_variables.clear();
 	}
 
+	G->user_config_dirty = 0;
 
 	fclose(f);
 

--- a/DirectX11/IniHandler.cpp
+++ b/DirectX11/IniHandler.cpp
@@ -4509,7 +4509,7 @@ void LoadConfigFile()
 	// TODO: Enable this by default if wider testing goes well:
 	G->check_foreground_window = GetIniBool(L"System", L"check_foreground_window", false, NULL);
 
-	// Allows to change interval between persistent vars autosaving to d3dx_user.ini (any negative number to disables it)
+	// Allows to change interval between persistent vars autosaving to d3dx_user.ini (any negative number to disable it)
 	G->gSettingsAutoSaveInterval = GetIniInt(L"System", L"settings_auto_save_interval", 60, NULL);
 	if (G->gSettingsAutoSaveInterval < 0) {
 		G->gSettingsAutoSaveInterval = 2147483647;
@@ -4845,13 +4845,52 @@ void SavePersistentSettings()
 
 	if (!G->user_config_dirty)
 		return;
-	G->user_config_dirty = 0;
 
 	setlocale(LC_CTYPE, "en_US.UTF-8");
 
 	// TODO: Ability to update existing file rather than overwriting:
 	//wfopen_ensuring_access(&f, G->user_config.c_str(), L"r+");
 	//if (!f)
+
+	std::unordered_map<std::wstring, float> saved_variables;
+
+	if (!G->gReloadConfigPending) {
+
+		// Read Existing Variables from File.
+		if (_wfopen_s(&f, G->user_config.c_str(), L"r") == 0 && f) {
+			wchar_t line[1024];
+
+			while (fgetws(line, _countof(line), f)) {
+				if (line[0] != L'$')
+					continue;
+
+				wchar_t* equals = wcschr(line, L'=');
+				if (!equals)
+					continue;
+
+				*equals = L'\0';
+
+				wchar_t* name_end = equals - 1;
+
+				while (name_end >= line &&
+					(*name_end == L' ' || *name_end == L'\t'))
+				{
+					name_end--;
+				}
+
+				*(name_end + 1) = L'\0';
+
+				float value;
+				if (swscanf_s(equals + 1, L"%f", &value) != 1)
+					continue;
+
+				saved_variables[line] = value;
+			}
+
+			fclose(f);
+		}
+	}
+
 	wfopen_ensuring_access(&f, G->user_config.c_str(), L"w");
 	if (!f) {
 		LogInfo("Unable to save settings in %S\n", G->user_config.c_str());
@@ -4869,8 +4908,25 @@ void SavePersistentSettings()
 	      ";\n"
 	      "[Constants]\n", f);
 
-	for (auto global : persistent_variables)
-		fprintf_s(f, "%ls = %.9g\n", global->name.c_str(), global->fval);
+
+	if (!G->gReloadConfigPending) {
+
+		for (auto global : persistent_variables) {
+			fprintf_s(f, "%ls = %.9g\n", global->name.c_str(), global->fval);
+			saved_variables.erase(global->name);
+		}
+
+		for (auto& entry : saved_variables)
+			fprintf_s(f, "%ls = %.9g\n", entry.first.c_str(), entry.second);
+	}
+	
+	else {
+		for (auto global : persistent_variables)
+			fprintf_s(f, "%ls = %.9g\n", global->name.c_str(), global->fval);
+
+		G->user_config_dirty = 0;
+	}
+
 
 	fclose(f);
 

--- a/DirectX11/IniHandler.cpp
+++ b/DirectX11/IniHandler.cpp
@@ -4857,40 +4857,12 @@ void SavePersistentSettings()
 
 	if (!G->user_config_dirty || !G->gConfigInitialized) {
 
-		// Read Existing Variables from File.
-		if (_wfopen_s(&f, G->user_config.c_str(), L"r") == 0 && f) {
-			wchar_t line[1024];
-
-			while (fgetws(line, _countof(line), f)) {
-				if (line[0] != L'$')
-					continue;
-
-				wchar_t* equals = wcschr(line, L'=');
-				if (!equals)
-					continue;
-
-				*equals = L'\0';
-
-				wchar_t* name_end = equals - 1;
-
-				while (name_end >= line && (*name_end == L' ' || *name_end == L'\t'))
-					name_end--;
-
-				*(name_end + 1) = L'\0';
-
-				float value;
-				if (swscanf_s(equals + 1, L"%f", &value) != 1)
-					continue;
-
-				saved_variables[line] = value;
-			}
-
-			fclose(f);
-		}
+		// Save Existing Variables
+		for (auto global : persistent_variables)
+			saved_variables[global->name.c_str()] = global->fval;
 
 		return;
 	}
-	
 
 	setlocale(LC_CTYPE, "en_US.UTF-8");
 
@@ -4936,7 +4908,12 @@ void SavePersistentSettings()
 		for (auto& entry : saved_variables)
 			fprintf_s(f, "%ls = %.9g\n", entry.first.c_str(), entry.second);
 
-		saved_variables.clear();
+		if (G->clear_saved_persist_vars) {
+			saved_variables.clear();
+			G->clear_saved_persist_vars = false;
+		}
+		else
+			G->clear_saved_persist_vars = true;
 	}
 
 	G->user_config_dirty = 0;

--- a/DirectX11/IniHandler.cpp
+++ b/DirectX11/IniHandler.cpp
@@ -4537,6 +4537,9 @@ void LoadConfigFile()
 		G->gFallbackScreenHeight = 1080;
 	}
 
+	// Controls whether saved values of persistent variables should be cleared when source mods are no longer detected (disabled or removed).
+	G->auto_clear_persist_vars = GetIniBool(L"System", L"auto_clear_persist_vars", true, NULL);
+
 	// [Device] (DXGI parameters)
 	LogInfo("[Device]\n");
 	G->SCREEN_WIDTH = GetIniInt(L"Device", L"width", -1, NULL);
@@ -4855,7 +4858,7 @@ void SavePersistentSettings()
 
 	G->gSettingsSaveTime = G->gTime;
 
-	if (!G->user_config_dirty || !G->gConfigInitialized) {
+	if (!G->user_config_dirty) {
 
 		// Save Existing Variables
 		for (auto global : persistent_variables)
@@ -4897,6 +4900,7 @@ void SavePersistentSettings()
 		fprintf_s(f, "%ls = %.9g\n", entry.first.c_str(), entry.second);
 
 	if (G->gReloadConfigPending && G->auto_clear_persist_vars) {
+
 		if (G->clear_saved_persist_vars) {
 			saved_variables.clear();
 			G->clear_saved_persist_vars = false;

--- a/DirectX11/globals.h
+++ b/DirectX11/globals.h
@@ -406,6 +406,7 @@ struct Globals
 	bool gLogInput;
 	bool gShowWarnings;
 	bool dump_all_profiles;
+	bool auto_clear_persist_vars;
 	unsigned gSystemTickCount;
 	float gTime;
 	float gSettingsSaveTime;
@@ -731,6 +732,7 @@ struct Globals
 		gFallbackScreenWidth(0),
 		gFallbackScreenHeight(0),
 		dump_all_profiles(false),
+		auto_clear_persist_vars(true),
 		gSystemTickCount(0),
 		gTime(0)
 	{

--- a/DirectX11/globals.h
+++ b/DirectX11/globals.h
@@ -407,6 +407,7 @@ struct Globals
 	bool gShowWarnings;
 	bool dump_all_profiles;
 	bool auto_clear_persist_vars;
+	bool clear_saved_persist_vars;
 	unsigned gSystemTickCount;
 	float gTime;
 	float gSettingsSaveTime;
@@ -733,6 +734,7 @@ struct Globals
 		gFallbackScreenHeight(0),
 		dump_all_profiles(false),
 		auto_clear_persist_vars(true),
+		clear_saved_persist_vars(false),
 		gSystemTickCount(0),
 		gTime(0)
 	{


### PR DESCRIPTION
Auto-Save Feature introduced a bug that caused Persist Variables to get Cleared behind the Scenes instead of during the 2nd Config Reload (F10).