### PR TITLE
Improve Performance of Optimize_Command_Lists

### DIFF
--- a/DirectX11/CommandList.cpp
+++ b/DirectX11/CommandList.cpp
@@ -8774,9 +8774,6 @@ bool IfCommand::optimise(HackerDevice *device)
 
 bool IfCommand::noop(bool post, bool ignore_cto_pre, bool ignore_cto_post)
 {
-	float static_val;
-	bool is_static;
-
 	if ((post && !post_finalised) || (!post && !pre_finalised)) {
 		LogOverlayW(LOG_WARNING, L"Statement \"if\" missing \"endif\":\n - \"%ls\"\n", ini_line.c_str());
 		return true;
@@ -8784,13 +8781,9 @@ bool IfCommand::noop(bool post, bool ignore_cto_pre, bool ignore_cto_post)
 
 	if (!static_evaluated)
 	{
-		static_value = 0.0f;
-		static_result = expression.static_evaluate(&static_value);
+		is_static = expression.static_evaluate(&static_val);
 		static_evaluated = true;
 	}
-
-	is_static = static_result;
-	static_val = static_value;
 
 	if (is_static) {
 		if (static_val) {

--- a/DirectX11/CommandList.cpp
+++ b/DirectX11/CommandList.cpp
@@ -8782,12 +8782,22 @@ bool IfCommand::noop(bool post, bool ignore_cto_pre, bool ignore_cto_post)
 		return true;
 	}
 
-	is_static = expression.static_evaluate(&static_val);
+	if (!static_evaluated)
+	{
+		static_value = 0.0f;
+		static_result = expression.static_evaluate(&static_value);
+		static_evaluated = true;
+	}
+
+	is_static = static_result;
+	static_val = static_value;
+
 	if (is_static) {
 		if (static_val) {
 			false_commands_pre->clear();
 			false_commands_post->clear();
-		} else {
+		}
+		else {
 			true_commands_pre->clear();
 			true_commands_post->clear();
 		}
@@ -8795,6 +8805,7 @@ bool IfCommand::noop(bool post, bool ignore_cto_pre, bool ignore_cto_post)
 
 	if (post)
 		return true_commands_post->noop() && false_commands_post->noop();
+
 	return true_commands_pre->noop() && false_commands_pre->noop();
 }
 

--- a/DirectX11/CommandList.h
+++ b/DirectX11/CommandList.h
@@ -1471,8 +1471,8 @@ public:
 	wstring section;
 
 	bool static_evaluated = false;
-	bool static_result = false;
-	float static_value = 0.0f;
+	bool is_static = false;
+	float static_val = 0.0f;
 
 	// Commands cannot statically contain command lists, because the
 	// command may be optimised out and the command list freed while we are

--- a/DirectX11/CommandList.h
+++ b/DirectX11/CommandList.h
@@ -1470,6 +1470,10 @@ public:
 	bool has_nested_else_if;
 	wstring section;
 
+	bool static_evaluated = false;
+	bool static_result = false;
+	float static_value = 0.0f;
+
 	// Commands cannot statically contain command lists, because the
 	// command may be optimised out and the command list freed while we are
 	// still in the middle of optimisations. These are dynamically


### PR DESCRIPTION
Add a Cache to IfCommand::noop to avoid evaluating the same Expression multiple times.