### PR TITLE
ShaderRegex background

### DIFF
--- a/D3D_Shaders/Assembler.cpp
+++ b/D3D_Shaders/Assembler.cpp
@@ -1,6 +1,8 @@
 #include "stdafx.h"
 #include "float.h"
 
+#include <mutex>
+
 #if MIGOTO_DX == 9
 #include <d3dx9shader.h>
 #endif
@@ -17,7 +19,11 @@ using namespace std;
 // for sscanf_s convinience. Explanation in DecompileHLSL.cpp
 #define UCOUNTOF(...) (unsigned)_countof(__VA_ARGS__)
 
+// Debug cache of opcode verification results, written during disassembly.
+// Guarded by a mutex because the ShaderRegex background worker disassembles
+// concurrently with the render thread (hunting, live shader reload, etc.).
 static unordered_map<string, vector<DWORD>> codeBin;
+static std::mutex codeBinMutex;
 
 static DWORD strToDWORD(string s)
 {
@@ -181,6 +187,10 @@ static string convertD(DWORD v1, DWORD v2)
 void writeLUT()
 {
 	FILE* f;
+
+	// Take the lock so we don't iterate codeBin while the ShaderRegex worker
+	// is concurrently adding to it during disassembly:
+	std::lock_guard<std::mutex> lock(codeBinMutex);
 
 	fopen_s(&f, "lut.asm", "wb");
 	if (!f)
@@ -2286,6 +2296,10 @@ static vector<DWORD> assembleIns(string s)
 
 static string assembleAndCompare(string s, vector<DWORD> v)
 {
+	// This may be running on the ShaderRegex background worker while the
+	// render thread disassembles another shader, so guard the shared cache:
+	std::lock_guard<std::mutex> lock(codeBinMutex);
+
 	string s2;
 	int numSpaces = 0;
 	while (memcmp(s.c_str(), " ", 1) == 0) {

--- a/Dependencies/d3dx.ini
+++ b/Dependencies/d3dx.ini
@@ -692,7 +692,7 @@ track_region_hashes = 0
 
 ; Enables buffer resizing for overrides, allowing vertex and structured buffers
 ; to be expanded beyond their original size. Primarily used for "vertex limit raise"
-; scenarios where the game’s default buffer size is too small.
+; scenarios where the gameï¿½s default buffer size is too small.
 ;
 ; When enabled, buffer size can be overridden using TextureOverride section parameters:
 ;
@@ -747,6 +747,13 @@ disassemble_undecipherable_custom_data = 1
 ; blocks when disassembling shaders so they match up with how they are accessed
 ; in the code, making things easier to follow and simplifying ShaderRegex.
 patch_assembly_cb_offsets = 1
+
+; Run ShaderRegex disassembly/matching/reassembly on a background thread so a
+; newly encountered shader never blocks the frame. The original shader keeps
+; being used until the replacement is ready, and is swapped in on a later draw
+; call. Set to 0 to use the legacy synchronous behaviour, which replaces the
+; shader in the very first draw call but may cause a hitch.
+shader_regex_background = 0
 
 ; Enables more sensible behaviour when including HLSL files from subdirectories
 ; that themselves include other files. Also disables backwards compatibility

--- a/DirectX11/HackerContext.cpp
+++ b/DirectX11/HackerContext.cpp
@@ -611,10 +611,11 @@ void HackerContext::DeferredShaderReplacement(ID3D11DeviceChild *shader, UINT64 
 			}
 
 			// Build an immutable snapshot of every matching ShaderRegex group
-			// on the render thread so it is consistent with the config:
+			// on the render thread so it is consistent with the config. Whether
+			// disassembly is needed is decided by the worker from the
+			// snapshot's patterns, so we don't need decompilation_required:
 			std::vector<ShaderRegexGroupSnapshot> snapshot;
-			bool decompilation_required = false;
-			build_shader_regex_group_snapshot(&orig_info->shaderModel, &snapshot, &decompilation_required);
+			build_shader_regex_group_snapshot(&orig_info->shaderModel, &snapshot, nullptr);
 
 			// Queue the job on the background worker. The worker first checks
 			// the on-disk cache, and only disassembles/matches/patches on a

--- a/DirectX11/HackerContext.cpp
+++ b/DirectX11/HackerContext.cpp
@@ -610,29 +610,19 @@ void HackerContext::DeferredShaderReplacement(ID3D11DeviceChild *shader, UINT64 
 				}
 			}
 
-			// Build an immutable snapshot of every matching ShaderRegex group
-			// on the render thread so it is consistent with the config. Whether
-			// disassembly is needed is decided by the worker from the
-			// snapshot's patterns, so we don't need decompilation_required:
-			std::vector<ShaderRegexGroupSnapshot> snapshot;
-			build_shader_regex_group_snapshot(&orig_info->shaderModel, &snapshot, nullptr);
-
 			// Queue the job on the background worker. The worker first checks
 			// the on-disk cache, and only disassembles/matches/patches on a
-			// miss. Until it completes we keep using the original shader, so
-			// this draw call is not blocked:
+			// miss (reading the live ShaderRegex groups directly - config
+			// reload waits for all jobs to finish first). Until it completes
+			// we keep using the original shader, so this draw call is not
+			// blocked:
 			job = std::make_shared<ShaderRegexJob>();
 			job->hash = hash;
 			job->shader_type = shader_type;
 			job->shader_model = orig_info->shaderModel;
-			job->shader_regex_hash = shader_regex_hash;
-			job->shader_cache_path = G->SHADER_CACHE_PATH;
 			job->bytecode.assign(
 					(byte*)orig_info->byteCode->GetBufferPointer(),
 					(byte*)orig_info->byteCode->GetBufferPointer() + orig_info->byteCode->GetBufferSize());
-			job->patch_cb_offsets = G->patch_cb_offsets;
-			job->disassemble_undecipherable_custom_data = G->disassemble_undecipherable_custom_data;
-			job->groups = std::move(snapshot);
 
 			orig_info->shader_regex_job = job;
 			orig_info->shader_regex_job_state = ShaderRegexJobState::PROCESSING;
@@ -680,28 +670,16 @@ void HackerContext::DeferredShaderReplacement(ID3D11DeviceChild *shader, UINT64 
 				}
 			}
 
-			// Build an immutable snapshot of every matching ShaderRegex group
-			// on the render thread so it is consistent with the config:
-			std::vector<ShaderRegexGroupSnapshot> snapshot;
 			bool decompilation_required = false;
-			build_shader_regex_group_snapshot(&orig_info->shaderModel, &snapshot, &decompilation_required);
+
+			// Process ShaderRegex sections that don't require bytecode
+			// decompilation:
+			link_shader_regex_groups_without_patterns(shader_type, &orig_info->shaderModel, hash, &decompilation_required);
 
 			// Skip disassemble entirely if there are no matching ShaderRegex
 			// with Patterns found:
 			if (!decompilation_required) {
 				LogInfo("%S %016I64x disassembly skipped: no matching ShaderRegex with Patterns found for %s.\n", shader_type, hash, orig_info->shaderModel.c_str());
-
-				// Enable CommandList sections execution for the no-pattern groups:
-				std::vector<uint32_t> match_ids;
-				for (auto &group_snap : snapshot) {
-					shader_regex_group_index[group_snap.group_index]->link_command_lists_and_filter_index(hash);
-					match_ids.push_back(group_snap.group_index);
-				}
-				// We save the cache metadata even if we didn't match anything.
-				// That way we can skip checking for a match next time when we
-				// know there won't be any.
-				save_shader_regex_cache_meta(hash, shader_type, &match_ids, false, nullptr, nullptr);
-
 				orig_info->shader_regex_job_state = ShaderRegexJobState::PROCESSED;
 				goto out_drop;
 			}

--- a/DirectX11/HackerContext.cpp
+++ b/DirectX11/HackerContext.cpp
@@ -533,13 +533,11 @@ void HackerContext::DeferredShaderReplacement(ID3D11DeviceChild *shader, UINT64 
 	ShaderReloadMap::iterator orig_info_i;
 	OriginalShaderInfo *orig_info = NULL;
 	UINT num_instances = 0;
-	string asm_text;
-	bool patch_regex = false;
 	HRESULT hr;
 	unsigned i;
 	wstring tagline(L"//");
 	vector<byte> patched_bytecode;
-	vector<char> asm_vector;
+	std::shared_ptr<ShaderRegexJob> job;
 
 	EnterCriticalSectionPretty(&G->mCriticalSection);
 
@@ -549,115 +547,225 @@ void HackerContext::DeferredShaderReplacement(ID3D11DeviceChild *shader, UINT64 
 		goto out_drop;
 	orig_info = &orig_info_i->second;
 
-	if (!orig_info->deferred_replacement_candidate || orig_info->deferred_replacement_processed)
+	if (!orig_info->deferred_replacement_candidate)
 		goto out_drop;
 
-	// Remember that we have analysed this one so we don't check it again
-	// (until config reload) regardless of whether we patch it or not:
-	orig_info->deferred_replacement_processed = true;
-
-	switch (load_shader_regex_cache(hash, shader_type, &patched_bytecode, &tagline)) {
-	case ShaderRegexCache::NO_MATCH:
-		LogInfo("%S %016I64x has cached ShaderRegex miss\n", shader_type, hash);
-		goto out_drop;
-	case ShaderRegexCache::MATCH:
-		LogInfo("Loaded %S %016I64x command list from ShaderRegex cache\n", shader_type, hash);
-		goto out_drop;
-	case ShaderRegexCache::PATCH:
-		LogInfo("Loaded %S %016I64x bytecode from ShaderRegex cache\n", shader_type, hash);
-		break;
-	case ShaderRegexCache::NO_CACHE:
-		LogInfo("Performing deferred shader analysis on %S %016I64x...\n", shader_type, hash);
-
-		// Detect shader model
-		auto it = G->mShaderModelCache.find(hash);
-		if (it != G->mShaderModelCache.end()) {
-			orig_info->shaderModel = it->second.shaderModel;
-			LogInfo("%S %016I64x shader model %s is loaded from cache.\n", shader_type, hash, orig_info->shaderModel.c_str());
-		}
-		else {
-			if (orig_info->shaderModel == "bin") {
-				// Get shader model from bytecode.
-				if (!get_shader_model_from_bytecode(orig_info->byteCode->GetBufferPointer(), orig_info->byteCode->GetBufferSize(), &orig_info->shaderModel)) {
-					LogInfo("%S %016I64x shader model detection from bytecode failed.\n", shader_type, hash);
-					goto out_drop;
-				}
-				// Store shader model in cache.
-				G->mShaderModelCache.emplace(hash, ShaderModelCacheEntry{ orig_info->shaderModel });
-				LogInfo("%S %016I64x shader model %s detected from bytecode.\n", shader_type, hash, orig_info->shaderModel.c_str());
-			}
-		}
-
-		bool decompilation_required = false;
-
-		// Process ShaderRegex sections that don't require bytecode decompilation.
-		link_shader_regex_groups_without_patterns(shader_type, &orig_info->shaderModel, hash, &decompilation_required);
-
-		// Skip disassemble entirely if there are no matching ShaderRegex with Patterns found.
-		if (!decompilation_required) {
-			LogInfo("%S %016I64x disassembly skipped: no matching ShaderRegex with Patterns found for %s.\n", shader_type, hash, orig_info->shaderModel.c_str());
+	// 1) A background job was submitted for this shader - check if it has
+	// finished. Until it does we keep using the original shader, so a new
+	// shader never blocks the render thread:
+	if (orig_info->shader_regex_job_state == ShaderRegexJobState::PROCESSING) {
+		job = orig_info->shader_regex_job;
+		if (!job || !job->done.load()) {
+			// Still analysing in the background - keep using the original shader:
 			goto out_drop;
 		}
 
-		// Disassemble shader bytecode.
-		asm_text = BinaryToAsmText(
-			orig_info->byteCode->GetBufferPointer(),
-			orig_info->byteCode->GetBufferSize(),
-			G->patch_cb_offsets,
-			G->disassemble_undecipherable_custom_data);
+		// Drop our reference to the job now that it has finished - it holds
+		// copies of the bytecode and patched assembly that we no longer need.
+		// The local `job` shared_ptr keeps it alive for the rest of this call:
+		orig_info->shader_regex_job.reset();
 
-		if (asm_text.empty())
-			goto out_drop;
+		// The analysis is done. Finalize on the render thread: link the
+		// command lists, write the cache and, if the shader was patched, hand
+		// back the replacement bytecode so we can create and bind it below:
+		if (finalize_shader_regex_job(job.get(), hash, shader_type, &patched_bytecode, &tagline)) {
+			orig_info->shader_regex_job_state = ShaderRegexJobState::PROCESSED;
 
-		asm_text = BinaryToAsmText(orig_info->byteCode->GetBufferPointer(),
-				orig_info->byteCode->GetBufferSize(),
-				G->patch_cb_offsets,
-				G->disassemble_undecipherable_custom_data);
-		if (asm_text.empty())
-			goto out_drop;
-
-		// Apply patches from ShaderRegex with Patterns (and Templates).
-		try {
-			patch_regex = apply_shader_regex_groups(&asm_text, shader_type, &orig_info->shaderModel, hash, &tagline);
-		} catch (...) {
-			LogInfo("    *** Exception while patching shader\n");
-			goto out_drop;
-		}
-
-		if (!patch_regex) {
-			LogInfo("Patch did not apply\n");
-			goto out_drop;
-		}
-
-		// No longer logging this since we can output to ShaderFixes
-		// via hunting if marking_actions = regex, or it could be
-		// disassembled from the regex cache with cmd_Decompiler
-		// LogInfo("Patched Shader:\n%s\n", asm_text.c_str());
-
-		asm_vector.assign(asm_text.begin(), asm_text.end());
-
-		try {
-			vector<AssemblerParseError> parse_errors;
-			hr = AssembleFluganWithSignatureParsing(&asm_vector, &patched_bytecode, &parse_errors);
-			if (FAILED(hr)) {
-				LogInfo("    *** Assembling patched shader failed\n");
-				goto out_drop;
-			}
 			// Parse errors are currently being treated as non-fatal on
 			// creation time replacement and ShaderRegex for backwards
-			// compatibility (live shader reload is fatal).
-			for (auto &parse_error : parse_errors)
+			// compatibility (live shader reload is fatal):
+			for (auto &msg : job->parse_error_messages)
 				LogOverlayW(LOG_NOTICE, L"%016I64x-%ls %ls: %S\n",
-						hash, shader_type, tagline.c_str(), parse_error.what());
-		} catch (const exception &e) {
-			LogOverlayW(LOG_WARNING, L"Error assembling ShaderRegex patched %016I64x-%ls\n%ls\n%S\n",
-					hash, shader_type, tagline.c_str(), e.what());
+						hash, shader_type, tagline.c_str(), msg.c_str());
+		} else {
+			orig_info->shader_regex_job_state = job->failed
+				? ShaderRegexJobState::FAILED : ShaderRegexJobState::PROCESSED;
+			goto out_drop;
+		}
+	}
+	// 2) Not processed yet. In background mode we hand everything (including
+	// the on-disk cache check) to the worker so the render thread does no file
+	// I/O and never blocks on a new shader:
+	else if (orig_info->shader_regex_job_state == ShaderRegexJobState::UNPROCESSED) {
+		if (G->shader_regex_background) {
+			LogInfo("Performing deferred shader analysis on %S %016I64x...\n", shader_type, hash);
+
+			// Detect shader model
+			auto it = G->mShaderModelCache.find(hash);
+			if (it != G->mShaderModelCache.end()) {
+				orig_info->shaderModel = it->second.shaderModel;
+				LogInfo("%S %016I64x shader model %s is loaded from cache.\n", shader_type, hash, orig_info->shaderModel.c_str());
+			}
+			else {
+				if (orig_info->shaderModel == "bin") {
+					// Get shader model from bytecode.
+					if (!get_shader_model_from_bytecode(orig_info->byteCode->GetBufferPointer(), orig_info->byteCode->GetBufferSize(), &orig_info->shaderModel)) {
+						LogInfo("%S %016I64x shader model detection from bytecode failed.\n", shader_type, hash);
+						orig_info->shader_regex_job_state = ShaderRegexJobState::FAILED;
+						goto out_drop;
+					}
+					// Store shader model in cache.
+					G->mShaderModelCache.emplace(hash, ShaderModelCacheEntry{ orig_info->shaderModel });
+					LogInfo("%S %016I64x shader model %s detected from bytecode.\n", shader_type, hash, orig_info->shaderModel.c_str());
+				}
+			}
+
+			// Build an immutable snapshot of every matching ShaderRegex group
+			// on the render thread so it is consistent with the config:
+			std::vector<ShaderRegexGroupSnapshot> snapshot;
+			bool decompilation_required = false;
+			build_shader_regex_group_snapshot(&orig_info->shaderModel, &snapshot, &decompilation_required);
+
+			// Queue the job on the background worker. The worker first checks
+			// the on-disk cache, and only disassembles/matches/patches on a
+			// miss. Until it completes we keep using the original shader, so
+			// this draw call is not blocked:
+			job = std::make_shared<ShaderRegexJob>();
+			job->hash = hash;
+			job->shader_type = shader_type;
+			job->shader_model = orig_info->shaderModel;
+			job->shader_regex_hash = shader_regex_hash;
+			job->shader_cache_path = G->SHADER_CACHE_PATH;
+			job->bytecode.assign(
+					(byte*)orig_info->byteCode->GetBufferPointer(),
+					(byte*)orig_info->byteCode->GetBufferPointer() + orig_info->byteCode->GetBufferSize());
+			job->patch_cb_offsets = G->patch_cb_offsets;
+			job->disassemble_undecipherable_custom_data = G->disassemble_undecipherable_custom_data;
+			job->groups = std::move(snapshot);
+
+			orig_info->shader_regex_job = job;
+			orig_info->shader_regex_job_state = ShaderRegexJobState::PROCESSING;
+			submit_shader_regex_job(std::move(job));
+			LogInfo("%S %016I64x queued for background ShaderRegex analysis\n", shader_type, hash);
 			goto out_drop;
 		}
 
-		save_shader_regex_cache_bin(hash, shader_type, &patched_bytecode);
-	}
+		// Legacy synchronous path (shader_regex_background = 0) - cache check
+		// and analysis all happen on the render thread. This blocks the render
+		// thread, but replaces the shader in the very draw call that first uses it:
+		switch (load_shader_regex_cache(hash, shader_type, &patched_bytecode, &tagline)) {
+		case ShaderRegexCache::NO_MATCH:
+			LogInfo("%S %016I64x has cached ShaderRegex miss\n", shader_type, hash);
+			orig_info->shader_regex_job_state = ShaderRegexJobState::PROCESSED;
+			goto out_drop;
+		case ShaderRegexCache::MATCH:
+			LogInfo("Loaded %S %016I64x command list from ShaderRegex cache\n", shader_type, hash);
+			orig_info->shader_regex_job_state = ShaderRegexJobState::PROCESSED;
+			goto out_drop;
+		case ShaderRegexCache::PATCH:
+			LogInfo("Loaded %S %016I64x bytecode from ShaderRegex cache\n", shader_type, hash);
+			orig_info->shader_regex_job_state = ShaderRegexJobState::PROCESSED;
+			break;
+		case ShaderRegexCache::NO_CACHE:
+			LogInfo("Performing deferred shader analysis on %S %016I64x...\n", shader_type, hash);
 
+			// Detect shader model
+			auto it = G->mShaderModelCache.find(hash);
+			if (it != G->mShaderModelCache.end()) {
+				orig_info->shaderModel = it->second.shaderModel;
+				LogInfo("%S %016I64x shader model %s is loaded from cache.\n", shader_type, hash, orig_info->shaderModel.c_str());
+			}
+			else {
+				if (orig_info->shaderModel == "bin") {
+					// Get shader model from bytecode.
+					if (!get_shader_model_from_bytecode(orig_info->byteCode->GetBufferPointer(), orig_info->byteCode->GetBufferSize(), &orig_info->shaderModel)) {
+						LogInfo("%S %016I64x shader model detection from bytecode failed.\n", shader_type, hash);
+						orig_info->shader_regex_job_state = ShaderRegexJobState::FAILED;
+						goto out_drop;
+					}
+					// Store shader model in cache.
+					G->mShaderModelCache.emplace(hash, ShaderModelCacheEntry{ orig_info->shaderModel });
+					LogInfo("%S %016I64x shader model %s detected from bytecode.\n", shader_type, hash, orig_info->shaderModel.c_str());
+				}
+			}
+
+			// Build an immutable snapshot of every matching ShaderRegex group
+			// on the render thread so it is consistent with the config:
+			std::vector<ShaderRegexGroupSnapshot> snapshot;
+			bool decompilation_required = false;
+			build_shader_regex_group_snapshot(&orig_info->shaderModel, &snapshot, &decompilation_required);
+
+			// Skip disassemble entirely if there are no matching ShaderRegex
+			// with Patterns found:
+			if (!decompilation_required) {
+				LogInfo("%S %016I64x disassembly skipped: no matching ShaderRegex with Patterns found for %s.\n", shader_type, hash, orig_info->shaderModel.c_str());
+
+				// Enable CommandList sections execution for the no-pattern groups:
+				std::vector<uint32_t> match_ids;
+				for (auto &group_snap : snapshot) {
+					shader_regex_group_index[group_snap.group_index]->link_command_lists_and_filter_index(hash);
+					match_ids.push_back(group_snap.group_index);
+				}
+				// We save the cache metadata even if we didn't match anything.
+				// That way we can skip checking for a match next time when we
+				// know there won't be any.
+				save_shader_regex_cache_meta(hash, shader_type, &match_ids, false, nullptr, nullptr);
+
+				orig_info->shader_regex_job_state = ShaderRegexJobState::PROCESSED;
+				goto out_drop;
+			}
+
+			// Legacy synchronous analysis:
+			{
+				string asm_text = BinaryToAsmText(
+						orig_info->byteCode->GetBufferPointer(),
+						orig_info->byteCode->GetBufferSize(),
+						G->patch_cb_offsets,
+						G->disassemble_undecipherable_custom_data);
+				if (asm_text.empty()) {
+					orig_info->shader_regex_job_state = ShaderRegexJobState::FAILED;
+					goto out_drop;
+				}
+
+				bool patch_regex = false;
+				try {
+					patch_regex = apply_shader_regex_groups(&asm_text, shader_type, &orig_info->shaderModel, hash, &tagline);
+				} catch (...) {
+					LogInfo("    *** Exception while patching shader\n");
+					orig_info->shader_regex_job_state = ShaderRegexJobState::FAILED;
+					goto out_drop;
+				}
+
+				if (!patch_regex) {
+					LogInfo("Patch did not apply\n");
+					orig_info->shader_regex_job_state = ShaderRegexJobState::PROCESSED;
+					goto out_drop;
+				}
+
+				vector<char> asm_vector(asm_text.begin(), asm_text.end());
+				try {
+					vector<AssemblerParseError> parse_errors;
+					hr = AssembleFluganWithSignatureParsing(&asm_vector, &patched_bytecode, &parse_errors);
+					if (FAILED(hr)) {
+						LogInfo("    *** Assembling patched shader failed\n");
+						orig_info->shader_regex_job_state = ShaderRegexJobState::FAILED;
+						goto out_drop;
+					}
+					// Parse errors are currently being treated as non-fatal on
+					// creation time replacement and ShaderRegex for backwards
+					// compatibility (live shader reload is fatal).
+					for (auto &parse_error : parse_errors)
+						LogOverlayW(LOG_NOTICE, L"%016I64x-%ls %ls: %S\n",
+								hash, shader_type, tagline.c_str(), parse_error.what());
+				} catch (const exception &e) {
+					LogOverlayW(LOG_WARNING, L"Error assembling ShaderRegex patched %016I64x-%ls\n%ls\n%S\n",
+							hash, shader_type, tagline.c_str(), e.what());
+					orig_info->shader_regex_job_state = ShaderRegexJobState::FAILED;
+					goto out_drop;
+				}
+
+				save_shader_regex_cache_bin(hash, shader_type, &patched_bytecode);
+				orig_info->shader_regex_job_state = ShaderRegexJobState::PROCESSED;
+			}
+			// Fall through to create and bind the replacement shader:
+		}
+	}
+	// 3) Already finalized or failed - nothing more to do this run:
+	else
+		goto out_drop;
+
+	// We have bytecode for a replacement shader - create it and bind it in
+	// time for this draw call:
 	hr = (mOrigDevice1->*CreateShader)(patched_bytecode.data(), patched_bytecode.size(),
 			orig_info->linkage, &patched_shader);
 	CleanupShaderMaps(patched_shader);

--- a/DirectX11/HackerDevice.cpp
+++ b/DirectX11/HackerDevice.cpp
@@ -531,7 +531,8 @@ static void RegisterForReload(ID3D11DeviceChild* ppShader, UINT64 hash, wstring 
 	G->mReloadedShaders[ppShader].replacement = NULL;
 	G->mReloadedShaders[ppShader].infoText = text;
 	G->mReloadedShaders[ppShader].deferred_replacement_candidate = deferred_replacement_candidate;
-	G->mReloadedShaders[ppShader].deferred_replacement_processed = false;
+	G->mReloadedShaders[ppShader].shader_regex_job_state = ShaderRegexJobState::UNPROCESSED;
+	G->mReloadedShaders[ppShader].shader_regex_job.reset();
 }
 
 

--- a/DirectX11/IniHandler.cpp
+++ b/DirectX11/IniHandler.cpp
@@ -4659,6 +4659,7 @@ void LoadConfigFile()
 	G->assemble_signature_comments = GetIniBool(L"Rendering", L"assemble_signature_comments", false, NULL);
 	G->disassemble_undecipherable_custom_data = GetIniBool(L"Rendering", L"disassemble_undecipherable_custom_data", false, NULL);
 	G->patch_cb_offsets = GetIniBool(L"Rendering", L"patch_assembly_cb_offsets", false, NULL);
+	G->shader_regex_background = GetIniBool(L"Rendering", L"shader_regex_background", false, NULL);
 	G->recursive_include = GetIniBoolOrInt(L"Rendering", L"recursive_include", false, NULL);
 
 	G->EXPORT_FIXED = GetIniBool(L"Rendering", L"export_fixed", false, NULL);
@@ -4954,14 +4955,16 @@ static void MarkAllShadersDeferredUnprocessed()
 	ShaderReloadMap::iterator i;
 
 	for (i = G->mReloadedShaders.begin(); i != G->mReloadedShaders.end(); i++) {
-		// Whenever we reload the config we clear the processed flag on
-		// all auto patched shaders to ensure that they will be
-		// re-patched using the current patterns in the d3dx.ini. This
-		// is separate from the deferred_replacement_candidate flag,
-		// which will be set in the shader reload routine for any
-		// shaders that have been removed from disk, and removed from
-		// any that are loaded from disk:
-		i->second.deferred_replacement_processed = false;
+		// Whenever we reload the config we reset the ShaderRegex job state on
+		// all auto patched shaders to ensure that they will be re-patched using
+		// the current patterns in the d3dx.ini. Any background job that is
+		// still in flight is simply dropped - its result would be stale, and a
+		// fresh job is queued the next time the shader is drawn. This is
+		// separate from the deferred_replacement_candidate flag, which will be
+		// set in the shader reload routine for any shaders that have been
+		// removed from disk, and removed from any that are loaded from disk:
+		i->second.shader_regex_job_state = ShaderRegexJobState::UNPROCESSED;
+		i->second.shader_regex_job.reset();
 	}
 
 	// TODO: If ShaderRegex hash is unchanged leave these shaders in place

--- a/DirectX11/IniHandler.cpp
+++ b/DirectX11/IniHandler.cpp
@@ -4992,6 +4992,13 @@ void ReloadConfig(HackerDevice *device)
 	// contexts) while we do this
 	EnterCriticalSectionPretty(&G->mCriticalSection);
 
+	// The background ShaderRegex worker reads the live ShaderRegex groups and
+	// other config globals directly. Wait for every queued and in-flight job
+	// to finish before we tear those structures down below - holding the
+	// critical section blocks any new jobs from being submitted, so this wait
+	// is bounded:
+	wait_for_shader_regex_jobs();
+
 	// Clears any notices currently displayed on the overlay. This ensures
 	// that any notices that haven't timed out yet (e.g. from a previous
 	// failed reload attempt) are removed so that the only messages

--- a/DirectX11/ShaderRegex.cpp
+++ b/DirectX11/ShaderRegex.cpp
@@ -767,13 +767,15 @@ bool get_shader_model_from_bytecode(const void* data, size_t size, std::string* 
 // given shader model, so the expensive disassembly/regex/reassembly work can
 // run on a background thread without touching the config reloadable
 // shader_regex_groups. Sets *decompilation_required if any matching group has
-// patterns (those are the only ones that require disassembly).
+// patterns (those are the only ones that require disassembly). May be NULL -
+// the background worker determines this itself from the snapshot's patterns.
 void build_shader_regex_group_snapshot(const std::string *shader_model,
 		std::vector<ShaderRegexGroupSnapshot> *snapshot, bool *decompilation_required)
 {
 	uint32_t j = 0;
 
-	*decompilation_required = false;
+	if (decompilation_required)
+		*decompilation_required = false;
 
 	for (auto &pair : shader_regex_groups) {
 		ShaderRegexGroup *group = &pair.second;
@@ -797,7 +799,7 @@ void build_shader_regex_group_snapshot(const std::string *shader_model,
 			group_snap.patterns.push_back(std::move(pattern_snap));
 		}
 
-		if (!group_snap.patterns.empty())
+		if (!group_snap.patterns.empty() && decompilation_required)
 			*decompilation_required = true;
 
 		LogDebug("ShaderRegex snapshot: %s matches [%S]\n", shader_model->c_str(), group->ini_section.c_str());
@@ -971,7 +973,10 @@ static void run_shader_regex_job(ShaderRegexJob *job)
 			job->patched_bytecode = std::move(cached_bytecode);
 
 			// Rebuild the tagline from the snapshot's section names - we can't
-			// touch the live groups from the worker:
+			// touch the live groups from the worker. Start with the same "//"
+			// prefix as the non-cached path (L1020) so Overlay's FindInfoText
+			// can uniformly skip the first two characters:
+			job->tagline = L"//";
 			for (uint32_t id : job->match_ids)
 				for (auto &group_snap : job->groups)
 					if (group_snap.group_index == id) {

--- a/DirectX11/ShaderRegex.cpp
+++ b/DirectX11/ShaderRegex.cpp
@@ -4,11 +4,24 @@
 #include "log.h"
 
 #include <algorithm>
+#include <atomic>
+#include <condition_variable>
+#include <deque>
 #include <iterator>
+#include <memory>
+#include <mutex>
+#include <thread>
 
 ShaderRegexGroups shader_regex_groups;
 std::vector<ShaderRegexGroup*> shader_regex_group_index;
 uint32_t shader_regex_hash;
+
+// Background ShaderRegex worker state. The worker processes one shader at a
+// time off the render thread so a new shader never blocks the frame.
+static std::mutex s_shader_regex_queue_mutex;
+static std::condition_variable s_shader_regex_queue_cv;
+static std::deque<std::shared_ptr<ShaderRegexJob>> s_shader_regex_queue;
+static bool s_shader_regex_worker_running = false;
 
 static void log_pcre2_error_nonl(int err, char *fmt, ...)
 {
@@ -154,6 +167,7 @@ bool ShaderRegexPattern::compile(std::string *pattern)
 	// CASELESS is for compatibility with d3dcompiler_46 & 47 without
 	// having to always remember to account for the dcl_constantbuffer
 	// differences:
+	this->pattern = *pattern;
 	regex = pcre2_compile((PCRE2_SPTR)pattern->c_str(),
 			pattern->length(), // or PCRE2_ZERO_TERMINATED
 			PCRE2_CASELESS | PCRE2_MULTILINE,
@@ -474,21 +488,30 @@ struct ShaderRegexCacheHeader {
 	uint32_t num_matches;
 };
 
-ShaderRegexCache load_shader_regex_cache(UINT64 hash, const wchar_t *shader_type, vector<byte> *bytecode, std::wstring *tagline)
+// Pure file-I/O read of the ShaderRegex cache for a shader. Fills in the
+// cached match ids and, for patched caches, the patched bytecode. It does NOT
+// touch the config reloadable shader_regex_groups nor link any command lists,
+// so it is safe to call from the background worker. The cache directory and
+// shader_regex_hash are snapshotted into the job so the worker never reads
+// globals that the render thread can reload.
+static ShaderRegexCache read_shader_regex_cache(const wchar_t *shader_cache_path, uint32_t shader_regex_hash_snapshot,
+		UINT64 hash, const wchar_t *shader_type, vector<uint32_t> *match_ids, vector<byte> *bytecode, bool *patched)
 {
 	ShaderRegexCache ret = ShaderRegexCache::NO_CACHE;
 	HANDLE meta_f = INVALID_HANDLE_VALUE;
 	HANDLE bin_f = INVALID_HANDLE_VALUE;
 	ShaderRegexCacheHeader *header;
-	ShaderRegexGroup *group;
 	wchar_t path[MAX_PATH];
-	uint32_t *match_ids;
+	uint32_t *file_match_ids;
 	DWORD size, size2;
 	byte *buf = NULL;
 	size_t suffix;
 	uint32_t i;
 
-	suffix = swprintf_s(path, MAX_PATH, L"%ls\\%016llx-%ls_regex.", G->SHADER_CACHE_PATH, hash, shader_type);
+	if (!shader_cache_path[0])
+		return ret;
+
+	suffix = swprintf_s(path, MAX_PATH, L"%ls\\%016llx-%ls_regex.", shader_cache_path, hash, shader_type);
 	wcscpy_s(path+suffix, MAX_PATH-suffix, L"dat");
 	meta_f = CreateFile(path, GENERIC_READ, FILE_SHARE_READ, 0, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 	if (meta_f == INVALID_HANDLE_VALUE)
@@ -504,14 +527,17 @@ ShaderRegexCache load_shader_regex_cache(UINT64 hash, const wchar_t *shader_type
 		goto out;
 
 	header = (ShaderRegexCacheHeader*)buf;
-	match_ids = (uint32_t*)(buf + sizeof(ShaderRegexCacheHeader));
+	file_match_ids = (uint32_t*)(buf + sizeof(ShaderRegexCacheHeader));
 
 	if (header->version != SHADER_REGEX_CACHE_VERSION
-	 || header->shader_regex_hash != shader_regex_hash)
+	 || header->shader_regex_hash != shader_regex_hash_snapshot)
 		goto out;
 
 	if (size != sizeof(ShaderRegexCacheHeader) + header->num_matches * sizeof(uint32_t))
 		goto out;
+
+	if (patched)
+		*patched = !!header->patched;
 
 	// num_matches may be 0, which means the ShaderRegex didn't match the
 	// shader, but we cache it anyway to skip processing the shader again.
@@ -523,22 +549,9 @@ ShaderRegexCache load_shader_regex_cache(UINT64 hash, const wchar_t *shader_type
 		goto out;
 	}
 
-	for (i = 0; i < header->num_matches; i++) {
-		// The ShaderRegex groups are sorted and since the cached hash
-		// already matched the map should be identical to when the
-		// cache was made, so we can use that to find the matching
-		// groups without having to do an expensive lookup by name:
-		if (match_ids[i] >= shader_regex_group_index.size())
-			goto out;
-		group = shader_regex_group_index[match_ids[i]];
-
-		LogInfo("ShaderRegexCache: %S %016I64x matches [%S]\n", shader_type, hash, group->ini_section.c_str());
-
-		if (header->patched && tagline)
-			tagline->append(std::wstring(L"[") + group->ini_section + std::wstring(L"]"));
-
-		group->link_command_lists_and_filter_index(hash);
-	}
+	match_ids->resize(header->num_matches);
+	for (i = 0; i < header->num_matches; i++)
+		(*match_ids)[i] = file_match_ids[i];
 
 	if (header->patched) {
 		wcscpy_s(path+suffix, MAX_PATH-suffix, L"bin");
@@ -563,7 +576,40 @@ out:
 	return ret;
 }
 
-static void save_shader_regex_cache_meta(UINT64 hash, const wchar_t *shader_type, vector<uint32_t> *match_ids,
+ShaderRegexCache load_shader_regex_cache(UINT64 hash, const wchar_t *shader_type, vector<byte> *bytecode, std::wstring *tagline)
+{
+	ShaderRegexCache ret;
+	ShaderRegexGroup *group;
+	vector<uint32_t> match_ids;
+	bool patched = false;
+
+	ret = read_shader_regex_cache(G->SHADER_CACHE_PATH, shader_regex_hash, hash, shader_type,
+			&match_ids, bytecode, &patched);
+
+	if (ret == ShaderRegexCache::NO_CACHE || ret == ShaderRegexCache::NO_MATCH)
+		return ret;
+
+	// The ShaderRegex groups are sorted and since the cached hash already
+	// matched the map should be identical to when the cache was made, so we
+	// can use that to find the matching groups without having to do an
+	// expensive lookup by name:
+	for (uint32_t match_id : match_ids) {
+		if (match_id >= shader_regex_group_index.size())
+			return ShaderRegexCache::NO_CACHE;
+		group = shader_regex_group_index[match_id];
+
+		LogInfo("ShaderRegexCache: %S %016I64x matches [%S]\n", shader_type, hash, group->ini_section.c_str());
+
+		if (patched && tagline)
+			tagline->append(std::wstring(L"[") + group->ini_section + std::wstring(L"]"));
+
+		group->link_command_lists_and_filter_index(hash);
+	}
+
+	return ret;
+}
+
+void save_shader_regex_cache_meta(UINT64 hash, const wchar_t *shader_type, vector<uint32_t> *match_ids,
 		bool patched, std::string *asm_text, std::wstring *tagline)
 {
 	ShaderRegexCacheHeader header;
@@ -717,46 +763,46 @@ bool get_shader_model_from_bytecode(const void* data, size_t size, std::string* 
 	return false;
 }
 
-// Process groups that do not have patches to apply. Those can be handled without disassembly.
-void link_shader_regex_groups_without_patterns(const wchar_t* shader_type, std::string* shader_model, UINT64 hash, bool* decompilation_required)
+// Build an immutable snapshot of every ShaderRegex group that matches the
+// given shader model, so the expensive disassembly/regex/reassembly work can
+// run on a background thread without touching the config reloadable
+// shader_regex_groups. Sets *decompilation_required if any matching group has
+// patterns (those are the only ones that require disassembly).
+void build_shader_regex_group_snapshot(const std::string *shader_model,
+		std::vector<ShaderRegexGroupSnapshot> *snapshot, bool *decompilation_required)
 {
-	ShaderRegexGroups::iterator i;
-	vector<uint32_t> match_ids;
-	vector<ShaderRegexGroup*> match_groups;
-	uint32_t j;
+	uint32_t j = 0;
 
-	for (i = shader_regex_groups.begin(), j = 0; i != shader_regex_groups.end(); i++, j++) {
-		ShaderRegexGroup* group = &i->second;
+	*decompilation_required = false;
+
+	for (auto &pair : shader_regex_groups) {
+		ShaderRegexGroup *group = &pair.second;
+		uint32_t group_index = j++;
 
 		// Skip group without matching shader model.
-		if (!group->shader_models.count(*shader_model)) {
+		if (!group->shader_models.count(*shader_model))
 			continue;
+
+		ShaderRegexGroupSnapshot group_snap;
+		group_snap.group_index = group_index;
+		group_snap.ini_section = group->ini_section;
+		group_snap.temp_regs = group->temp_regs;
+		group_snap.declarations = group->declarations;
+
+		for (auto &pattern_pair : group->patterns) {
+			ShaderRegexPatternSnapshot pattern_snap;
+			pattern_snap.pattern = pattern_pair.second.pattern;
+			pattern_snap.replace = pattern_pair.second.replace;
+			pattern_snap.do_replace = pattern_pair.second.do_replace;
+			group_snap.patterns.push_back(std::move(pattern_snap));
 		}
 
-		// Skip group with patterns. Those ones need txt to match.
-		if (!group->patterns.empty()) {
-			if (decompilation_required)
-				*decompilation_required = true;
-			continue;
-		}
+		if (!group_snap.patterns.empty())
+			*decompilation_required = true;
 
-		match_ids.push_back(j);
-		match_groups.push_back(group);
+		LogDebug("ShaderRegex snapshot: %s matches [%S]\n", shader_model->c_str(), group->ini_section.c_str());
 
-		LogInfo("ShaderRegex (no pattern): %S %016I64x matches [%S]\n", shader_type, hash, group->ini_section.c_str());
-	}
-
-	// If no ShaderRegEx requires decompilation, link CommandLists and update shader cache here instead of `apply_shader_regex_groups`. 
-	if (decompilation_required && !*decompilation_required) {
-		// Enable CommandList sections execution for this group.
-		for (ShaderRegexGroup* group : match_groups) {
-			group->link_command_lists_and_filter_index(hash);
-		}
-		// We save the cache metadata even if we didn't match anything. That
-		// way we can skip checking for a match next time when we know there
-		// won't be any. This only saves the metadata - the caller will use
-		// save_shader_regex_cache_bin to save the assembled binary.
-		save_shader_regex_cache_meta(hash, shader_type, &match_ids, false, nullptr, nullptr);
+		snapshot->push_back(std::move(group_snap));
 	}
 }
 
@@ -805,4 +851,313 @@ bool apply_shader_regex_groups(std::string *asm_text, const wchar_t *shader_type
 	save_shader_regex_cache_meta(hash, shader_type, &match_ids, patched, asm_text, tagline);
 
 	return patched;
+}
+
+// -----------------------------------------------------------------------------
+// Background ShaderRegex worker.
+//
+// Disassembling, regex matching and re-assembling a shader is expensive, so we
+// run it on a background thread and keep using the original shader until the
+// replacement is ready. This means a new shader never blocks the render thread
+// - it is swapped to the patched shader on a later draw call instead.
+//
+// Thread safety:
+//  - The worker only ever touches the immutable ShaderRegexGroupSnapshot data
+//    captured at submit time, never the config reloadable shader_regex_groups
+//    or any DirectX state.
+//  - Linking the command lists (which the draw call code executes) and writing
+//    the shader cache happen on the render thread in finalize_shader_regex_job.
+//  - LogInfo is safe to call from multiple threads because the CRT serializes
+//    access to a shared FILE* stream.
+// -----------------------------------------------------------------------------
+
+// Mirrors ShaderRegexGroup::apply_regex_patterns, but works purely on an
+// immutable snapshot and recompiles the regexes locally on the worker thread.
+static void apply_regex_patterns_to_snapshot(ShaderRegexGroupSnapshot *group_snap, std::string *asm_text,
+		bool *match_out, bool *patch_out)
+{
+	unsigned dcl_temps = 0;
+
+	// Match defaults to true so that if there are no patterns we can still
+	// apply the command list. Patch defaults to false because we don't want to
+	// waste time re-assembling the shader if we didn't change it.
+	*match_out = true;
+	*patch_out = false;
+
+	if (!group_snap->temp_regs.empty())
+		dcl_temps = get_dcl_temps(asm_text);
+
+	for (auto &pattern_snap : group_snap->patterns) {
+		ShaderRegexPattern pattern;
+
+		// Compiled regexes are cheap to produce compared to the disassembly
+		// and reassembly work they replace, and keep the worker independent
+		// of the live (config reloadable) groups:
+		if (!pattern.compile(&pattern_snap.pattern)) {
+			*match_out = false;
+			*patch_out = false;
+			return;
+		}
+		pattern.do_replace = pattern_snap.do_replace;
+		pattern.replace = pattern_snap.replace;
+
+		if (pattern.do_replace)
+			*match_out = *patch_out = pattern.patch(asm_text, &group_snap->temp_regs, dcl_temps);
+		else
+			*match_out = pattern.matches(asm_text);
+
+		if (!*match_out) {
+			*patch_out = false;
+			return;
+		}
+	}
+
+	// Only update dcl_temps if we are patching:
+	if (*patch_out && !group_snap->temp_regs.empty())
+		*patch_out = update_dcl_temps(asm_text, dcl_temps + group_snap->temp_regs.size());
+
+	// But we can update declarations even if we aren't doing a regex replace in
+	// some cases, so long as the patterns all matched:
+	if (!group_snap->declarations.empty())
+		*patch_out = insert_declarations(asm_text, &group_snap->declarations) || *patch_out;
+}
+
+// Execute one job on the worker thread. Only fills in the job result - it never
+// touches the render thread's state.
+static void run_shader_regex_job(ShaderRegexJob *job)
+{
+	// 1) Try the on-disk cache first so the render thread never does file I/O
+	// when a shader is first used:
+	std::vector<byte> cached_bytecode;
+	std::vector<uint32_t> cached_match_ids;
+	bool cached_patched = false;
+	ShaderRegexCache cache = read_shader_regex_cache(job->shader_cache_path.c_str(), job->shader_regex_hash,
+			job->hash, job->shader_type.c_str(), &cached_match_ids, &cached_bytecode, &cached_patched);
+
+	if (cache == ShaderRegexCache::NO_MATCH) {
+		// Cached miss - nothing to link and nothing to patch:
+		job->from_cache = true;
+		job->done.store(true);
+		return;
+	}
+
+	if (cache == ShaderRegexCache::MATCH || cache == ShaderRegexCache::PATCH) {
+		job->from_cache = true;
+		job->match_ids = std::move(cached_match_ids);
+
+		// The cached groups all matched this shader model, so they must be
+		// present in our snapshot. Treat a cache that references unknown groups
+		// as stale and re-analyse the shader instead:
+		bool valid = true;
+		for (uint32_t id : job->match_ids) {
+			bool found = false;
+			for (auto &group_snap : job->groups) {
+				if (group_snap.group_index == id) {
+					found = true;
+					break;
+				}
+			}
+			if (!found) {
+				valid = false;
+				break;
+			}
+		}
+		if (!valid) {
+			LogInfo("ShaderRegexCache: %S %016I64x stale cache, re-analysing\n", job->shader_type.c_str(), job->hash);
+			job->from_cache = false;
+			job->match_ids.clear();
+		} else if (cache == ShaderRegexCache::PATCH) {
+			job->patched = true;
+			job->patched_bytecode = std::move(cached_bytecode);
+
+			// Rebuild the tagline from the snapshot's section names - we can't
+			// touch the live groups from the worker:
+			for (uint32_t id : job->match_ids)
+				for (auto &group_snap : job->groups)
+					if (group_snap.group_index == id) {
+						job->tagline.append(std::wstring(L"[") + group_snap.ini_section + std::wstring(L"]"));
+						break;
+					}
+			job->done.store(true);
+			return;
+		} else {
+			job->done.store(true);
+			return;
+		}
+	}
+
+	// 2) No usable cache - analyse the shader. If none of the matching groups
+	// have patterns, no disassembly is needed - their command lists still get
+	// linked, but we can skip the expensive decompile:
+	bool any_patterns = false;
+	for (auto &group_snap : job->groups) {
+		if (!group_snap.patterns.empty()) {
+			any_patterns = true;
+			break;
+		}
+	}
+
+	if (!any_patterns) {
+		for (auto &group_snap : job->groups)
+			job->match_ids.push_back(group_snap.group_index);
+		job->done.store(true);
+		return;
+	}
+
+	// Disassemble the shader bytecode to assembly text:
+	std::string asm_text = BinaryToAsmText(job->bytecode.data(), job->bytecode.size(),
+			job->patch_cb_offsets, job->disassemble_undecipherable_custom_data);
+	if (asm_text.empty()) {
+		LogInfo("  Background ShaderRegex disassembly failed for %S %016I64x\n", job->shader_type.c_str(), job->hash);
+		job->failed = true;
+		job->done.store(true);
+		return;
+	}
+
+	// Apply every matching group. Groups without patterns always "match" so that
+	// their command lists can be linked; groups with patterns must match (and may
+	// patch) the assembly:
+	std::wstring tagline(L"//");
+	std::vector<uint32_t> match_ids;
+	bool patched = false;
+
+	for (auto &group_snap : job->groups) {
+		if (group_snap.patterns.empty()) {
+			match_ids.push_back(group_snap.group_index);
+			continue;
+		}
+
+		bool match, patch;
+		apply_regex_patterns_to_snapshot(&group_snap, &asm_text, &match, &patch);
+		if (!match)
+			continue;
+
+		LogInfo("ShaderRegex: %s %016I64x matches [%S]\n",
+				job->shader_model.c_str(), job->hash, group_snap.ini_section.c_str());
+		patched = patched || patch;
+
+		// Append section to patch sequence:
+		if (patch)
+			tagline.append(std::wstring(L"[") + group_snap.ini_section + std::wstring(L"]"));
+
+		match_ids.push_back(group_snap.group_index);
+	}
+
+	job->match_ids = std::move(match_ids);
+	job->tagline = std::move(tagline);
+
+	if (patched) {
+		// Reassemble the patched assembly back into bytecode on the worker:
+		std::vector<char> asm_vector(asm_text.begin(), asm_text.end());
+		try {
+			std::vector<AssemblerParseError> parse_errors;
+			HRESULT hr = AssembleFluganWithSignatureParsing(&asm_vector, &job->patched_bytecode, &parse_errors);
+			if (FAILED(hr)) {
+				LogInfo("    *** Background ShaderRegex assembling patched shader failed\n");
+				job->failed = true;
+				job->done.store(true);
+				return;
+			}
+			// Parse errors are currently treated as non-fatal - remember them so
+			// the render thread can log them to the OSD:
+			for (auto &parse_error : parse_errors)
+				job->parse_error_messages.push_back(parse_error.what());
+			job->patched_asm = std::move(asm_text);
+			job->patched = true;
+		} catch (const std::exception &e) {
+			LogInfo("    *** Background ShaderRegex assembling patched shader threw: %s\n", e.what());
+			job->failed = true;
+		}
+	}
+
+	job->done.store(true);
+}
+
+static void shader_regex_worker_main()
+{
+	// Run at a low priority so disassembling/reassembling a shader in the
+	// background never competes with the render thread for CPU time. This is
+	// what makes the delayed replacement effectively invisible even on low
+	// core-count CPUs - the worker only runs when the game leaves CPU time
+	// available, and lets the render thread have it back whenever it is needed:
+	SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_BELOW_NORMAL);
+
+	for (;;) {
+		std::shared_ptr<ShaderRegexJob> job;
+
+		{
+			std::unique_lock<std::mutex> lock(s_shader_regex_queue_mutex);
+			s_shader_regex_queue_cv.wait(lock, [] { return !s_shader_regex_queue.empty(); });
+			job = std::move(s_shader_regex_queue.front());
+			s_shader_regex_queue.pop_front();
+		}
+
+		run_shader_regex_job(job.get());
+	}
+}
+
+void submit_shader_regex_job(std::shared_ptr<ShaderRegexJob> job)
+{
+	{
+		std::lock_guard<std::mutex> lock(s_shader_regex_queue_mutex);
+		s_shader_regex_queue.push_back(std::move(job));
+	}
+	s_shader_regex_queue_cv.notify_one();
+
+	// Lazily start the worker thread on the first job:
+	std::lock_guard<std::mutex> lock(s_shader_regex_queue_mutex);
+	if (s_shader_regex_worker_running)
+		return;
+	s_shader_regex_worker_running = true;
+	try {
+		std::thread(shader_regex_worker_main).detach();
+	} catch (const std::system_error &) {
+		// Couldn't start the worker thread (e.g. out of resources). Fail every
+		// queued job so no shader stays stuck in PROCESSING forever; they will
+		// fall back to using the original shader until the next config reload:
+		LogInfo("WARNING: ShaderRegex worker thread creation failed\n");
+		s_shader_regex_worker_running = false;
+		for (auto &queued : s_shader_regex_queue) {
+			queued->failed = true;
+			queued->done.store(true);
+		}
+		s_shader_regex_queue.clear();
+	}
+}
+
+bool finalize_shader_regex_job(ShaderRegexJob *job, UINT64 hash, const wchar_t *shader_type,
+		std::vector<byte> *out_bytecode, std::wstring *out_tagline)
+{
+	// Linking the command lists must happen on the render thread because the
+	// ShaderOverride command lists are executed by the draw call code:
+	for (uint32_t match_id : job->match_ids) {
+		if (match_id >= shader_regex_group_index.size()) {
+			LogInfo("%S %016I64x ShaderRegex finalize failed: match id out of range\n", shader_type, hash);
+			job->failed = true;
+			return false;
+		}
+		shader_regex_group_index[match_id]->link_command_lists_and_filter_index(hash);
+	}
+
+	if (job->failed)
+		return false;
+
+	if (job->patched) {
+		if (!job->from_cache) {
+			// Only write the cache when we analysed the shader ourselves - a
+			// cache hit already has its cache on disk:
+			save_shader_regex_cache_meta(hash, shader_type, &job->match_ids, true, &job->patched_asm, &job->tagline);
+			save_shader_regex_cache_bin(hash, shader_type, &job->patched_bytecode);
+		}
+		*out_bytecode = job->patched_bytecode;
+		*out_tagline = job->tagline;
+		return true;
+	}
+
+	if (!job->from_cache) {
+		// Matched but nothing was patched - cache the metadata anyway so the
+		// command list matching isn't repeated next time:
+		save_shader_regex_cache_meta(hash, shader_type, &job->match_ids, false, nullptr, nullptr);
+	}
+	return false;
 }

--- a/DirectX11/ShaderRegex.cpp
+++ b/DirectX11/ShaderRegex.cpp
@@ -16,13 +16,6 @@ ShaderRegexGroups shader_regex_groups;
 std::vector<ShaderRegexGroup*> shader_regex_group_index;
 uint32_t shader_regex_hash;
 
-// Background ShaderRegex worker state. The worker processes one shader at a
-// time off the render thread so a new shader never blocks the frame.
-static std::mutex s_shader_regex_queue_mutex;
-static std::condition_variable s_shader_regex_queue_cv;
-static std::deque<std::shared_ptr<ShaderRegexJob>> s_shader_regex_queue;
-static bool s_shader_regex_worker_running = false;
-
 static void log_pcre2_error_nonl(int err, char *fmt, ...)
 {
 	PCRE2_UCHAR buf[120]; // doco says "120 code units is ample"
@@ -491,10 +484,10 @@ struct ShaderRegexCacheHeader {
 // Pure file-I/O read of the ShaderRegex cache for a shader. Fills in the
 // cached match ids and, for patched caches, the patched bytecode. It does NOT
 // touch the config reloadable shader_regex_groups nor link any command lists,
-// so it is safe to call from the background worker. The cache directory and
-// shader_regex_hash are snapshotted into the job so the worker never reads
-// globals that the render thread can reload.
-static ShaderRegexCache read_shader_regex_cache(const wchar_t *shader_cache_path, uint32_t shader_regex_hash_snapshot,
+// so it is safe to call from the background worker. The worker reads the live
+// shader_regex_hash and G->SHADER_CACHE_PATH directly - this is safe because
+// config reload waits for all background jobs to finish before changing them.
+static ShaderRegexCache read_shader_regex_cache(const wchar_t *shader_cache_path, uint32_t current_shader_regex_hash,
 		UINT64 hash, const wchar_t *shader_type, vector<uint32_t> *match_ids, vector<byte> *bytecode, bool *patched)
 {
 	ShaderRegexCache ret = ShaderRegexCache::NO_CACHE;
@@ -530,7 +523,7 @@ static ShaderRegexCache read_shader_regex_cache(const wchar_t *shader_cache_path
 	file_match_ids = (uint32_t*)(buf + sizeof(ShaderRegexCacheHeader));
 
 	if (header->version != SHADER_REGEX_CACHE_VERSION
-	 || header->shader_regex_hash != shader_regex_hash_snapshot)
+	 || header->shader_regex_hash != current_shader_regex_hash)
 		goto out;
 
 	if (size != sizeof(ShaderRegexCacheHeader) + header->num_matches * sizeof(uint32_t))
@@ -763,59 +756,71 @@ bool get_shader_model_from_bytecode(const void* data, size_t size, std::string* 
 	return false;
 }
 
-// Build an immutable snapshot of every ShaderRegex group that matches the
-// given shader model, so the expensive disassembly/regex/reassembly work can
-// run on a background thread without touching the config reloadable
-// shader_regex_groups. Sets *decompilation_required if any matching group has
-// patterns (those are the only ones that require disassembly). May be NULL -
-// the background worker determines this itself from the snapshot's patterns.
-void build_shader_regex_group_snapshot(const std::string *shader_model,
-		std::vector<ShaderRegexGroupSnapshot> *snapshot, bool *decompilation_required)
+// Process groups that do not have patches to apply. Those can be handled
+// without disassembly. Sets *decompilation_required if any group matching the
+// shader model has patterns (those are the only ones that require
+// disassembly). Called on the render thread only - it links command lists,
+// which must never happen on the background worker.
+void link_shader_regex_groups_without_patterns(const wchar_t* shader_type, std::string* shader_model, UINT64 hash, bool* decompilation_required)
 {
-	uint32_t j = 0;
+	ShaderRegexGroups::iterator i;
+	vector<uint32_t> match_ids;
+	vector<ShaderRegexGroup*> match_groups;
+	uint32_t j;
 
 	if (decompilation_required)
 		*decompilation_required = false;
 
-	for (auto &pair : shader_regex_groups) {
-		ShaderRegexGroup *group = &pair.second;
-		uint32_t group_index = j++;
+	for (i = shader_regex_groups.begin(), j = 0; i != shader_regex_groups.end(); i++, j++) {
+		ShaderRegexGroup* group = &i->second;
 
 		// Skip group without matching shader model.
-		if (!group->shader_models.count(*shader_model))
+		if (!group->shader_models.count(*shader_model)) {
 			continue;
-
-		ShaderRegexGroupSnapshot group_snap;
-		group_snap.group_index = group_index;
-		group_snap.ini_section = group->ini_section;
-		group_snap.temp_regs = group->temp_regs;
-		group_snap.declarations = group->declarations;
-
-		for (auto &pattern_pair : group->patterns) {
-			ShaderRegexPatternSnapshot pattern_snap;
-			pattern_snap.pattern = pattern_pair.second.pattern;
-			pattern_snap.replace = pattern_pair.second.replace;
-			pattern_snap.do_replace = pattern_pair.second.do_replace;
-			group_snap.patterns.push_back(std::move(pattern_snap));
 		}
 
-		if (!group_snap.patterns.empty() && decompilation_required)
-			*decompilation_required = true;
+		// Skip group with patterns. Those ones need txt to match.
+		if (!group->patterns.empty()) {
+			if (decompilation_required)
+				*decompilation_required = true;
+			continue;
+		}
 
-		LogDebug("ShaderRegex snapshot: %s matches [%S]\n", shader_model->c_str(), group->ini_section.c_str());
+		match_ids.push_back(j);
+		match_groups.push_back(group);
 
-		snapshot->push_back(std::move(group_snap));
+		LogInfo("ShaderRegex (no pattern): %S %016I64x matches [%S]\n", shader_type, hash, group->ini_section.c_str());
+	}
+
+	// If no ShaderRegEx requires decompilation, link CommandLists and update
+	// the shader cache here instead of `apply_shader_regex_groups`:
+	if (decompilation_required && !*decompilation_required) {
+		// Enable CommandList sections execution for this group.
+		for (ShaderRegexGroup* group : match_groups) {
+			group->link_command_lists_and_filter_index(hash);
+		}
+		// We save the cache metadata even if we didn't match anything. That
+		// way we can skip checking for a match next time when we know there
+		// won't be any. This only saves the metadata - the caller will use
+		// save_shader_regex_cache_bin to save the assembled binary.
+		save_shader_regex_cache_meta(hash, shader_type, &match_ids, false, nullptr, nullptr);
 	}
 }
 
-bool apply_shader_regex_groups(std::string *asm_text, const wchar_t *shader_type, std::string *shader_model, UINT64 hash, std::wstring *tagline)
+// Match and patch every ShaderRegex group that matches the shader model against
+// the disassembled asm text, collecting the indices of all matched groups. This
+// is pure computation - it does NOT link command lists or write the cache, so it
+// is safe to call from the background worker (which may only read the live
+// shader_regex_groups; config reload waits for all jobs to finish first).
+static void match_shader_regex_groups(std::string *asm_text, const std::string *shader_model, UINT64 hash,
+		std::vector<uint32_t> *match_ids, bool *patched, std::wstring *tagline)
 {
 	ShaderRegexGroups::iterator i;
 	ShaderRegexGroup *group;
-	bool patched = false;
 	bool match, patch;
-	vector<uint32_t> match_ids;
 	uint32_t j;
+
+	*patched = false;
 
 	for (i = shader_regex_groups.begin(), j = 0; i != shader_regex_groups.end(); i++, j++) {
 		group = &i->second;
@@ -833,18 +838,27 @@ bool apply_shader_regex_groups(std::string *asm_text, const wchar_t *shader_type
 				continue;
 
 			LogInfo("ShaderRegex: %s %016I64x matches [%S]\n", shader_model->c_str(), hash, group->ini_section.c_str());
-			patched = patched || patch;
+			*patched = *patched || patch;
 
 			// Append section to patch sequence.
 			if (patch && tagline)
 				tagline->append(std::wstring(L"[") + group->ini_section + std::wstring(L"]"));
 		}
 
-		match_ids.push_back(j);
-
-		// Enable CommandList sections execution for this group.
-		group->link_command_lists_and_filter_index(hash);
+		match_ids->push_back(j);
 	}
+}
+
+bool apply_shader_regex_groups(std::string *asm_text, const wchar_t *shader_type, std::string *shader_model, UINT64 hash, std::wstring *tagline)
+{
+	vector<uint32_t> match_ids;
+	bool patched = false;
+
+	match_shader_regex_groups(asm_text, shader_model, hash, &match_ids, &patched, tagline);
+
+	// Enable CommandList sections execution for every matched group:
+	for (uint32_t match_id : match_ids)
+		shader_regex_group_index[match_id]->link_command_lists_and_filter_index(hash);
 
 	// We save the cache metadata even if we didn't match anything. That
 	// way we can skip checking for a match next time when we know there
@@ -864,76 +878,116 @@ bool apply_shader_regex_groups(std::string *asm_text, const wchar_t *shader_type
 // - it is swapped to the patched shader on a later draw call instead.
 //
 // Thread safety:
-//  - The worker only ever touches the immutable ShaderRegexGroupSnapshot data
-//    captured at submit time, never the config reloadable shader_regex_groups
-//    or any DirectX state.
+//  - The worker only ever READS the live shader_regex_groups /
+//    shader_regex_group_index / shader_regex_hash / G globals. It never
+//    modifies them, and config reload calls wait_for_shader_regex_jobs()
+//    before rebuilding them, so there is no concurrent read/write.
 //  - Linking the command lists (which the draw call code executes) and writing
 //    the shader cache happen on the render thread in finalize_shader_regex_job.
 //  - LogInfo is safe to call from multiple threads because the CRT serializes
 //    access to a shared FILE* stream.
 // -----------------------------------------------------------------------------
 
-// Mirrors ShaderRegexGroup::apply_regex_patterns, but works purely on an
-// immutable snapshot and recompiles the regexes locally on the worker thread.
-static void apply_regex_patterns_to_snapshot(ShaderRegexGroupSnapshot *group_snap, std::string *asm_text,
-		bool *match_out, bool *patch_out)
+class ShaderRegexWorker {
+public:
+	// Queue a shader to be processed. The caller keeps the job alive (e.g. in
+	// orig_info->shader_regex_job) until job->done is true, then calls
+	// finalize_shader_regex_job on the render thread.
+	void Submit(std::shared_ptr<ShaderRegexJob> job);
+
+	// Block until every queued and in-flight job has finished. Must be called
+	// on the render thread before the ShaderRegex data structures the worker
+	// reads are torn down (e.g. during config reload).
+	void WaitForIdle();
+
+private:
+	void WorkerMain();
+	void RunJob(ShaderRegexJob *job);
+
+	std::mutex queue_mutex;
+	std::condition_variable queue_cv;
+	std::deque<std::shared_ptr<ShaderRegexJob>> queue;
+	bool running = false;
+	bool busy = false;
+};
+
+static ShaderRegexWorker g_shader_regex_worker;
+
+void ShaderRegexWorker::Submit(std::shared_ptr<ShaderRegexJob> job)
 {
-	unsigned dcl_temps = 0;
-
-	// Match defaults to true so that if there are no patterns we can still
-	// apply the command list. Patch defaults to false because we don't want to
-	// waste time re-assembling the shader if we didn't change it.
-	*match_out = true;
-	*patch_out = false;
-
-	if (!group_snap->temp_regs.empty())
-		dcl_temps = get_dcl_temps(asm_text);
-
-	for (auto &pattern_snap : group_snap->patterns) {
-		ShaderRegexPattern pattern;
-
-		// Compiled regexes are cheap to produce compared to the disassembly
-		// and reassembly work they replace, and keep the worker independent
-		// of the live (config reloadable) groups:
-		if (!pattern.compile(&pattern_snap.pattern)) {
-			*match_out = false;
-			*patch_out = false;
-			return;
-		}
-		pattern.do_replace = pattern_snap.do_replace;
-		pattern.replace = pattern_snap.replace;
-
-		if (pattern.do_replace)
-			*match_out = *patch_out = pattern.patch(asm_text, &group_snap->temp_regs, dcl_temps);
-		else
-			*match_out = pattern.matches(asm_text);
-
-		if (!*match_out) {
-			*patch_out = false;
-			return;
-		}
+	{
+		std::lock_guard<std::mutex> lock(queue_mutex);
+		queue.push_back(std::move(job));
 	}
+	queue_cv.notify_one();
 
-	// Only update dcl_temps if we are patching:
-	if (*patch_out && !group_snap->temp_regs.empty())
-		*patch_out = update_dcl_temps(asm_text, dcl_temps + group_snap->temp_regs.size());
+	// Lazily start the worker thread on the first job:
+	std::lock_guard<std::mutex> lock(queue_mutex);
+	if (running)
+		return;
+	running = true;
+	try {
+		std::thread(&ShaderRegexWorker::WorkerMain, this).detach();
+	} catch (const std::system_error &) {
+		// Couldn't start the worker thread (e.g. out of resources). Fail every
+		// queued job so no shader stays stuck in PROCESSING forever; they will
+		// fall back to using the original shader until the next config reload:
+		LogInfo("WARNING: ShaderRegex worker thread creation failed\n");
+		running = false;
+		for (auto &queued : queue) {
+			queued->failed = true;
+			queued->done.store(true);
+		}
+		queue.clear();
+	}
+}
 
-	// But we can update declarations even if we aren't doing a regex replace in
-	// some cases, so long as the patterns all matched:
-	if (!group_snap->declarations.empty())
-		*patch_out = insert_declarations(asm_text, &group_snap->declarations) || *patch_out;
+void ShaderRegexWorker::WaitForIdle()
+{
+	std::unique_lock<std::mutex> lock(queue_mutex);
+	queue_cv.wait(lock, [this] { return queue.empty() && !busy; });
+}
+
+void ShaderRegexWorker::WorkerMain()
+{
+	// Run at a low priority so disassembling/reassembling a shader in the
+	// background never competes with the render thread for CPU time. This is
+	// what makes the delayed replacement effectively invisible even on low
+	// core-count CPUs - the worker only runs when the game leaves CPU time
+	// available, and lets the render thread have it back whenever it is needed:
+	SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_BELOW_NORMAL);
+
+	for (;;) {
+		std::shared_ptr<ShaderRegexJob> job;
+		{
+			std::unique_lock<std::mutex> lock(queue_mutex);
+			queue_cv.wait(lock, [this] { return !queue.empty(); });
+			job = std::move(queue.front());
+			queue.pop_front();
+			busy = true;
+		}
+
+		RunJob(job.get());
+
+		{
+			std::lock_guard<std::mutex> lock(queue_mutex);
+			busy = false;
+		}
+		// Wake up any thread waiting for the queue to drain (config reload):
+		queue_cv.notify_all();
+	}
 }
 
 // Execute one job on the worker thread. Only fills in the job result - it never
 // touches the render thread's state.
-static void run_shader_regex_job(ShaderRegexJob *job)
+void ShaderRegexWorker::RunJob(ShaderRegexJob *job)
 {
 	// 1) Try the on-disk cache first so the render thread never does file I/O
 	// when a shader is first used:
 	std::vector<byte> cached_bytecode;
 	std::vector<uint32_t> cached_match_ids;
 	bool cached_patched = false;
-	ShaderRegexCache cache = read_shader_regex_cache(job->shader_cache_path.c_str(), job->shader_regex_hash,
+	ShaderRegexCache cache = read_shader_regex_cache(G->SHADER_CACHE_PATH, shader_regex_hash,
 			job->hash, job->shader_type.c_str(), &cached_match_ids, &cached_bytecode, &cached_patched);
 
 	if (cache == ShaderRegexCache::NO_MATCH) {
@@ -947,19 +1001,11 @@ static void run_shader_regex_job(ShaderRegexJob *job)
 		job->from_cache = true;
 		job->match_ids = std::move(cached_match_ids);
 
-		// The cached groups all matched this shader model, so they must be
-		// present in our snapshot. Treat a cache that references unknown groups
-		// as stale and re-analyse the shader instead:
+		// Treat a cache that references groups which no longer exist as stale
+		// and re-analyse the shader instead:
 		bool valid = true;
 		for (uint32_t id : job->match_ids) {
-			bool found = false;
-			for (auto &group_snap : job->groups) {
-				if (group_snap.group_index == id) {
-					found = true;
-					break;
-				}
-			}
-			if (!found) {
+			if (id >= shader_regex_group_index.size()) {
 				valid = false;
 				break;
 			}
@@ -971,18 +1017,9 @@ static void run_shader_regex_job(ShaderRegexJob *job)
 		} else if (cache == ShaderRegexCache::PATCH) {
 			job->patched = true;
 			job->patched_bytecode = std::move(cached_bytecode);
-
-			// Rebuild the tagline from the snapshot's section names - we can't
-			// touch the live groups from the worker. Start with the same "//"
-			// prefix as the non-cached path (L1020) so Overlay's FindInfoText
-			// can uniformly skip the first two characters:
 			job->tagline = L"//";
 			for (uint32_t id : job->match_ids)
-				for (auto &group_snap : job->groups)
-					if (group_snap.group_index == id) {
-						job->tagline.append(std::wstring(L"[") + group_snap.ini_section + std::wstring(L"]"));
-						break;
-					}
+				job->tagline.append(std::wstring(L"[") + shader_regex_group_index[id]->ini_section + std::wstring(L"]"));
 			job->done.store(true);
 			return;
 		} else {
@@ -994,61 +1031,31 @@ static void run_shader_regex_job(ShaderRegexJob *job)
 	// 2) No usable cache - analyse the shader. If none of the matching groups
 	// have patterns, no disassembly is needed - their command lists still get
 	// linked, but we can skip the expensive decompile:
-	bool any_patterns = false;
-	for (auto &group_snap : job->groups) {
-		if (!group_snap.patterns.empty()) {
-			any_patterns = true;
+	bool need_disasm = false;
+	for (auto &pair : shader_regex_groups) {
+		if (pair.second.shader_models.count(job->shader_model) && !pair.second.patterns.empty()) {
+			need_disasm = true;
 			break;
 		}
 	}
 
-	if (!any_patterns) {
-		for (auto &group_snap : job->groups)
-			job->match_ids.push_back(group_snap.group_index);
-		job->done.store(true);
-		return;
-	}
-
-	// Disassemble the shader bytecode to assembly text:
-	std::string asm_text = BinaryToAsmText(job->bytecode.data(), job->bytecode.size(),
-			job->patch_cb_offsets, job->disassemble_undecipherable_custom_data);
-	if (asm_text.empty()) {
-		LogInfo("  Background ShaderRegex disassembly failed for %S %016I64x\n", job->shader_type.c_str(), job->hash);
-		job->failed = true;
-		job->done.store(true);
-		return;
-	}
-
-	// Apply every matching group. Groups without patterns always "match" so that
-	// their command lists can be linked; groups with patterns must match (and may
-	// patch) the assembly:
-	std::wstring tagline(L"//");
-	std::vector<uint32_t> match_ids;
-	bool patched = false;
-
-	for (auto &group_snap : job->groups) {
-		if (group_snap.patterns.empty()) {
-			match_ids.push_back(group_snap.group_index);
-			continue;
+	std::string asm_text;
+	if (need_disasm) {
+		asm_text = BinaryToAsmText(job->bytecode.data(), job->bytecode.size(),
+				G->patch_cb_offsets, G->disassemble_undecipherable_custom_data);
+		if (asm_text.empty()) {
+			LogInfo("  Background ShaderRegex disassembly failed for %S %016I64x\n", job->shader_type.c_str(), job->hash);
+			job->failed = true;
+			job->done.store(true);
+			return;
 		}
-
-		bool match, patch;
-		apply_regex_patterns_to_snapshot(&group_snap, &asm_text, &match, &patch);
-		if (!match)
-			continue;
-
-		LogInfo("ShaderRegex: %s %016I64x matches [%S]\n",
-				job->shader_model.c_str(), job->hash, group_snap.ini_section.c_str());
-		patched = patched || patch;
-
-		// Append section to patch sequence:
-		if (patch)
-			tagline.append(std::wstring(L"[") + group_snap.ini_section + std::wstring(L"]"));
-
-		match_ids.push_back(group_snap.group_index);
 	}
 
-	job->match_ids = std::move(match_ids);
+	// Match/patch every matching group and collect the matched indices. This is
+	// safe to call from the worker because it only reads the live groups:
+	bool patched = false;
+	std::wstring tagline(L"//");
+	match_shader_regex_groups(&asm_text, &job->shader_model, job->hash, &job->match_ids, &patched, &tagline);
 	job->tagline = std::move(tagline);
 
 	if (patched) {
@@ -1078,56 +1085,14 @@ static void run_shader_regex_job(ShaderRegexJob *job)
 	job->done.store(true);
 }
 
-static void shader_regex_worker_main()
-{
-	// Run at a low priority so disassembling/reassembling a shader in the
-	// background never competes with the render thread for CPU time. This is
-	// what makes the delayed replacement effectively invisible even on low
-	// core-count CPUs - the worker only runs when the game leaves CPU time
-	// available, and lets the render thread have it back whenever it is needed:
-	SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_BELOW_NORMAL);
-
-	for (;;) {
-		std::shared_ptr<ShaderRegexJob> job;
-
-		{
-			std::unique_lock<std::mutex> lock(s_shader_regex_queue_mutex);
-			s_shader_regex_queue_cv.wait(lock, [] { return !s_shader_regex_queue.empty(); });
-			job = std::move(s_shader_regex_queue.front());
-			s_shader_regex_queue.pop_front();
-		}
-
-		run_shader_regex_job(job.get());
-	}
-}
-
 void submit_shader_regex_job(std::shared_ptr<ShaderRegexJob> job)
 {
-	{
-		std::lock_guard<std::mutex> lock(s_shader_regex_queue_mutex);
-		s_shader_regex_queue.push_back(std::move(job));
-	}
-	s_shader_regex_queue_cv.notify_one();
+	g_shader_regex_worker.Submit(std::move(job));
+}
 
-	// Lazily start the worker thread on the first job:
-	std::lock_guard<std::mutex> lock(s_shader_regex_queue_mutex);
-	if (s_shader_regex_worker_running)
-		return;
-	s_shader_regex_worker_running = true;
-	try {
-		std::thread(shader_regex_worker_main).detach();
-	} catch (const std::system_error &) {
-		// Couldn't start the worker thread (e.g. out of resources). Fail every
-		// queued job so no shader stays stuck in PROCESSING forever; they will
-		// fall back to using the original shader until the next config reload:
-		LogInfo("WARNING: ShaderRegex worker thread creation failed\n");
-		s_shader_regex_worker_running = false;
-		for (auto &queued : s_shader_regex_queue) {
-			queued->failed = true;
-			queued->done.store(true);
-		}
-		s_shader_regex_queue.clear();
-	}
+void wait_for_shader_regex_jobs()
+{
+	g_shader_regex_worker.WaitForIdle();
 }
 
 bool finalize_shader_regex_job(ShaderRegexJob *job, UINT64 hash, const wchar_t *shader_type,

--- a/DirectX11/ShaderRegex.h
+++ b/DirectX11/ShaderRegex.h
@@ -28,8 +28,7 @@ enum class ShaderRegexJobState : uint8_t {
 	FAILED           // Analysis failed; no replacement until config reload.
 };
 
-// Forward declarations - full definitions at the bottom of this header:
-struct ShaderRegexGroupSnapshot;
+// Forward declaration - full definition at the bottom of this header:
 struct ShaderRegexJob;
 
 bool get_shader_model_from_bytecode(const void* data, size_t size, std::string* out_model);
@@ -73,8 +72,7 @@ struct ShaderBindings
 	std::array<ShaderResource, D3D11_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT> resources{};
 };
 
-void build_shader_regex_group_snapshot(const std::string *shader_model,
-		std::vector<ShaderRegexGroupSnapshot> *snapshot, bool *decompilation_required);
+void link_shader_regex_groups_without_patterns(const wchar_t* shader_type, std::string* shader_model, UINT64 hash, bool* decompilation_required);
 bool apply_shader_regex_groups(std::string *asm_text, const wchar_t *shader_type, std::string *shader_model, UINT64 hash, std::wstring *tagline);
 ShaderRegexCache load_shader_regex_cache(UINT64 hash, const wchar_t *shader_type, vector<byte> *bytecode, std::wstring *tagline);
 void save_shader_regex_cache_bin(UINT64 hash, const wchar_t *shader_type, vector<byte> *bytecode);
@@ -85,6 +83,12 @@ bool unlink_shader_regex_command_lists_and_filter_index(UINT64 shader_hash);
 // Submit a shader to the background ShaderRegex worker. The caller keeps the
 // job alive and must wait for job->done before calling finalize_shader_regex_job.
 void submit_shader_regex_job(std::shared_ptr<ShaderRegexJob> job);
+
+// Block until every queued and in-flight background job has finished. Must be
+// called on the render thread (e.g. from config reload) before the worker's
+// inputs (shader_regex_groups / shader_regex_group_index / shader_regex_hash,
+// etc.) are torn down or rebuilt.
+void wait_for_shader_regex_jobs();
 
 // Called on the render thread (under the global lock) once job->done is true.
 // Links command lists for every matched group and writes the shader cache.
@@ -157,43 +161,19 @@ extern std::vector<ShaderRegexGroup*> shader_regex_group_index;
 // cached shader is still valid and to avoid discarding regex patched shaders:
 extern uint32_t shader_regex_hash;
 
-// Immutable snapshot of a single regex pattern, handed to the background worker
-// so that it never has to touch the config reloadable shader_regex_groups.
-// The worker recompiles the regex locally from this source string.
-struct ShaderRegexPatternSnapshot {
-	std::string pattern;
-	std::string replace;
-	bool do_replace = false;
-};
-
-// Immutable snapshot of a ShaderRegexGroup that matched the shader model.
-struct ShaderRegexGroupSnapshot {
-	uint32_t group_index = 0;     // index into shader_regex_group_index
-	std::wstring ini_section;
-	std::vector<ShaderRegexPatternSnapshot> patterns;
-	std::vector<std::string> declarations;
-	ShaderRegexTemps temp_regs;
-};
-
 // A background job that disassembles, regex matches/patches and reassembles a
 // single shader off the render thread. Owned by shared_ptr: created and
 // consumed on the render thread, executed by the worker thread.
+//
+// The worker reads the live shader_regex_groups / shader_regex_group_index /
+// shader_regex_hash / G globals directly - this is safe because config reload
+// calls wait_for_shader_regex_jobs() before tearing those down.
 struct ShaderRegexJob {
 	// Input (render thread -> worker):
 	UINT64 hash = 0;
 	std::wstring shader_type;
 	std::string shader_model;
 	std::vector<byte> bytecode;               // copy of the original bytecode
-	bool patch_cb_offsets = false;
-	bool disassemble_undecipherable_custom_data = true;
-	std::vector<ShaderRegexGroupSnapshot> groups;
-
-	// Snapshots of config values so the worker never reads globals that the
-	// render thread can reload. The cache directory is used for the on-disk
-	// cache check, and shader_regex_hash validates that a cache is still
-	// current:
-	std::wstring shader_cache_path;
-	uint32_t shader_regex_hash = 0;
 
 	// Worker -> render thread result. done is the synchronisation point: the
 	// worker writes all results before storing true (release), and the render

--- a/DirectX11/ShaderRegex.h
+++ b/DirectX11/ShaderRegex.h
@@ -6,6 +6,8 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <memory>
+#include <atomic>
 
 #include <pcre2.h>
 
@@ -15,6 +17,20 @@ enum class ShaderRegexCache {
 	MATCH,
 	PATCH
 };
+
+// State of the deferred ShaderRegex background processing for a single shader.
+// Stored on OriginalShaderInfo so the render thread never blocks on the
+// disassembly/regex/reassembly work, which now runs on a background thread.
+enum class ShaderRegexJobState : uint8_t {
+	UNPROCESSED = 0, // No analysis has been started yet.
+	PROCESSING,      // A background job is in flight; keep using the original shader.
+	PROCESSED,       // Analysis finalized (replacement bound, or none required).
+	FAILED           // Analysis failed; no replacement until config reload.
+};
+
+// Forward declarations - full definitions at the bottom of this header:
+struct ShaderRegexGroupSnapshot;
+struct ShaderRegexJob;
 
 bool get_shader_model_from_bytecode(const void* data, size_t size, std::string* out_model);
 
@@ -57,11 +73,24 @@ struct ShaderBindings
 	std::array<ShaderResource, D3D11_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT> resources{};
 };
 
-void link_shader_regex_groups_without_patterns(const wchar_t* shader_type, std::string* shader_model, UINT64 hash, bool* decompilation_required);
+void build_shader_regex_group_snapshot(const std::string *shader_model,
+		std::vector<ShaderRegexGroupSnapshot> *snapshot, bool *decompilation_required);
 bool apply_shader_regex_groups(std::string *asm_text, const wchar_t *shader_type, std::string *shader_model, UINT64 hash, std::wstring *tagline);
 ShaderRegexCache load_shader_regex_cache(UINT64 hash, const wchar_t *shader_type, vector<byte> *bytecode, std::wstring *tagline);
 void save_shader_regex_cache_bin(UINT64 hash, const wchar_t *shader_type, vector<byte> *bytecode);
+void save_shader_regex_cache_meta(UINT64 hash, const wchar_t *shader_type, vector<uint32_t> *match_ids,
+		bool patched, std::string *asm_text, std::wstring *tagline);
 bool unlink_shader_regex_command_lists_and_filter_index(UINT64 shader_hash);
+
+// Submit a shader to the background ShaderRegex worker. The caller keeps the
+// job alive and must wait for job->done before calling finalize_shader_regex_job.
+void submit_shader_regex_job(std::shared_ptr<ShaderRegexJob> job);
+
+// Called on the render thread (under the global lock) once job->done is true.
+// Links command lists for every matched group and writes the shader cache.
+// Returns true if a replacement shader should be created and bound.
+bool finalize_shader_regex_job(ShaderRegexJob *job, UINT64 hash, const wchar_t *shader_type,
+		std::vector<byte> *out_bytecode, std::wstring *out_tagline);
 
 typedef std::set<std::string> ShaderRegexTemps;
 typedef std::set<std::string> ShaderRegexModels;
@@ -69,6 +98,7 @@ typedef std::set<std::string> ShaderRegexModels;
 class ShaderRegexPattern {
 public:
 	pcre2_code *regex;
+	std::string pattern;
 	std::string replace;
 
 	bool do_replace;
@@ -126,3 +156,55 @@ extern std::vector<ShaderRegexGroup*> shader_regex_group_index;
 // This hash is of all ShaderRegex sections and is used to determine if a
 // cached shader is still valid and to avoid discarding regex patched shaders:
 extern uint32_t shader_regex_hash;
+
+// Immutable snapshot of a single regex pattern, handed to the background worker
+// so that it never has to touch the config reloadable shader_regex_groups.
+// The worker recompiles the regex locally from this source string.
+struct ShaderRegexPatternSnapshot {
+	std::string pattern;
+	std::string replace;
+	bool do_replace = false;
+};
+
+// Immutable snapshot of a ShaderRegexGroup that matched the shader model.
+struct ShaderRegexGroupSnapshot {
+	uint32_t group_index = 0;     // index into shader_regex_group_index
+	std::wstring ini_section;
+	std::vector<ShaderRegexPatternSnapshot> patterns;
+	std::vector<std::string> declarations;
+	ShaderRegexTemps temp_regs;
+};
+
+// A background job that disassembles, regex matches/patches and reassembles a
+// single shader off the render thread. Owned by shared_ptr: created and
+// consumed on the render thread, executed by the worker thread.
+struct ShaderRegexJob {
+	// Input (render thread -> worker):
+	UINT64 hash = 0;
+	std::wstring shader_type;
+	std::string shader_model;
+	std::vector<byte> bytecode;               // copy of the original bytecode
+	bool patch_cb_offsets = false;
+	bool disassemble_undecipherable_custom_data = true;
+	std::vector<ShaderRegexGroupSnapshot> groups;
+
+	// Snapshots of config values so the worker never reads globals that the
+	// render thread can reload. The cache directory is used for the on-disk
+	// cache check, and shader_regex_hash validates that a cache is still
+	// current:
+	std::wstring shader_cache_path;
+	uint32_t shader_regex_hash = 0;
+
+	// Worker -> render thread result. done is the synchronisation point: the
+	// worker writes all results before storing true (release), and the render
+	// thread reads them only after observing true (acquire).
+	std::atomic<bool> done{ false };
+	bool failed = false;                      // disassembly or assembly failed
+	bool patched = false;                     // at least one pattern produced a patch
+	bool from_cache = false;                  // result came from the on-disk cache
+	std::vector<uint32_t> match_ids;          // indices into shader_regex_group_index
+	std::vector<byte> patched_bytecode;
+	std::string patched_asm;                  // kept for the EXPORT_FIXED cache .txt
+	std::vector<std::string> parse_error_messages;
+	std::wstring tagline;
+};

--- a/DirectX11/globals.h
+++ b/DirectX11/globals.h
@@ -124,7 +124,14 @@ struct OriginalShaderInfo
 	ID3D11DeviceChild* replacement;
 	bool found;
 	bool deferred_replacement_candidate;
-	bool deferred_replacement_processed;
+
+	// State of the deferred ShaderRegex background processing. The heavy
+	// disassembly/regex/reassembly work runs on a background thread while the
+	// original shader keeps being used; the replacement is bound only once the
+	// job completes (or a cache hit is found).
+	ShaderRegexJobState shader_regex_job_state = ShaderRegexJobState::UNPROCESSED;
+	std::shared_ptr<ShaderRegexJob> shader_regex_job;
+
 	std::wstring infoText;
 };
 
@@ -487,6 +494,13 @@ struct Globals
 	bool assemble_signature_comments;
 	bool disassemble_undecipherable_custom_data;
 	bool patch_cb_offsets;
+
+	// When true, ShaderRegex analysis runs on a background thread and the
+	// original shader keeps being used until the replacement is ready. When
+	// false (default) the analysis runs synchronously on the render thread,
+	// which may cause a hitch the first time a new shader is used.
+	bool shader_regex_background;
+
 	int recursive_include;
 	uint32_t ZBufferHashToInject;
 	DecompilerSettings decompiler_settings;
@@ -701,6 +715,7 @@ struct Globals
 		EXPORT_BINARY(false),
 		CACHE_SHADERS(false),
 		DumpUsage(false),
+		shader_regex_background(false),
 		ENABLE_TUNE(false),
 		gTuneStep(0.001f),
 


### PR DESCRIPTION
ShaderRegex always stutters in the face of new shaders that appear in the game, which greatly affects the experience of playing.

This leads players and authors to dislike ShaderRegex, even though it is a high-cap feature.

`cache_shaders` can alleviate this problem, but I want to suggest a new approach:

**Let ShaderRegex work in the background, no longer sync with rendering, and replace it when ShaderRegex is complete.**

1. This eliminates stuttering caused by shaders that are not expected by regex.
2. For target shaders that are expected by regex, this just changes from stuttering to delay.

I added a `shader_regex_background = 1 / 0` in `[Rendering]` to switch this function on and off.

There may still be unknown bugs, but for now I am playing normally in wuwa (you know, wuwa has a terrible number of world shaders)

❤️🩷🧡💛💚💙🩵💜🤎🖤🩶🤍**Finally, thank you for supporting ps-t0->format, which is very helpful for locking target shaders and binding maps. Many authors use this method or rabbitfx regularization to combat hash updates**